### PR TITLE
Automatic Controller Chained Groups Detection

### DIFF
--- a/hector_controller_spawner/README.md
+++ b/hector_controller_spawner/README.md
@@ -1,32 +1,50 @@
-# Hector Controller Spawner - Multispawner – ROS2 Hardware & Controller Launcher
+# Hector Controller Spawner – **Multispawner**
 
-Multispawner is a lightweight ROS2 node that boots an entire *ros2\_control* setup in a single shot. It resolves the tedium of juggling multiple **spawner** processes by batching every step:
+**ROS2 Hardware & Controller Launcher for `ros2_control`**
 
-* **Wait‑for‑safety/Wait-for-Hardware:** Optionally blocks on an emergency‑stop (`std_msgs/Bool`) topic before doing anything. The motors may be impossible to activate while the e‑stop is engaged.
-* **Hardware first:** Ensures every listed hardware interface is *loaded* **and** *active* (with automatic retries).
-* **Smart loading:** Loads only the controllers that are missing (skips those already present).
-* **Reduced overhead:** No per‑controller spawner nodes required, just one multispawner node.
-
----
-
-## Key Parameters
-
-| Name                      | Type       | Default | Purpose                                                             |
-| ------------------------- | ---------- | ------- |---------------------------------------------------------------------|
-| `hardware_interfaces`     | `string[]` | —       | Ordered list of hardware interface names to activate.               |
-| `controllers`             | `string[]` | —       | Ordered list of controller names under management.                  |
-| `<ctrl>.activate`         | `bool`     | `true`  | Activate this controller after loading?                             |
-| `<ctrl>.activate_as_group`| `string[]` | —       | Controller groups that are activated togehter.                      |
-| `retry_delay`             | `double`   | `5.0`   | Seconds between retry attempts.                                     |
-| `estop_topic`             | `string`   | ""      | Topic to wait on (false ⇒ proceed). Empty string disables the gate. |
-
-See **athena.yaml** for a full example.
+**Multispawner** is a minimal ROS2 node that launches an entire `ros2_control` setup in a single coordinated pass.
+It robustly manages hardware interfaces and controllers, ensuring everything is loaded, activated (if required), and
+ready to go with minimal configuration.
 
 ---
 
-## Typical Usage
+## 🚀 Features
+
+* **Wait-for-safety (e-stop):** Optionally blocks on an `std_msgs/Bool` topic (e.g., emergency stop) before starting.
+  Useful when motors can't be activated while safety is engaged.
+* **Re-activation:** Automatically reactivates hardware interfaces and controllers after releasing the e-stop (if they
+  became inactive).
+* **Controller Manager Synchronization:** Waits for the controller manager to become available before proceeding.
+* **Hardware-first strategy:** Ensures all listed hardware interfaces are both *loaded* and *activated* (with automatic
+  retries on failure).
+* **Intelligent controller loading:** Skips controllers already present - only loads and activates what’s missing.
+* **Automatic chaining:** Automatically detects and starts *chained controllers* together - no additional config
+  required.
+* **Single-node simplicity:** No need to spawn one spawner per controller - Multispawner handles everything.
+* **Robust retry logic:** Retries failed hardware/controller activations with configurable delays.
+
+---
+
+## 🔧 Key Parameters
+
+| Name                  | Type       | Default | Description                                                               |
+|-----------------------|------------|---------|---------------------------------------------------------------------------|
+| `hardware_interfaces` | `string[]` | -       | Ordered list of hardware interface names to activate.                     |
+| `controllers`         | `string[]` | -       | Ordered list of controller names to load and manage.                      |
+| `<ctrl>.activate`     | `bool`     | `true`  | Should the controller be activated after loading?                         |
+| `retry_delay`         | `double`   | `5.0`   | Delay (in seconds) between retry attempts.                                |
+| `estop_topic`         | `string`   | `""`    | Topic to wait on (false ⇒ proceed). Leave empty to disable e-stop gating. |
+
+📄 See [`athena.yaml`](config/athena.yaml) for a complete configuration example.
+
+---
+
+## 🧪 Example Usage
 
 ```bash
 ros2 launch hector_controller_spawner hector_controller_spawner_launch.yml
 ```
-Add it to a launch file exactly once—no per‑controller spawner nodes required.
+
+* Include **only once** in your launch setup.
+* No need for individual `spawner` calls per controller.
+

--- a/hector_controller_spawner/config/athena.yaml
+++ b/hector_controller_spawner/config/athena.yaml
@@ -31,11 +31,9 @@
 
     self_collision_avoidance_controller:
       activate: true
-      activate_as_group: ["flipper_velocity_controller"]
 
     flipper_velocity_controller:
       activate: true
-      activate_as_group: ["self_collision_avoidance_controller"]
 
     gripper_trajectory_controller:
       activate: true

--- a/hector_controller_spawner/config/athena.yaml
+++ b/hector_controller_spawner/config/athena.yaml
@@ -12,7 +12,7 @@
       - "athena_flipper_interface"
       - "athena_arm_interface"
 
-    # ---------- controllers, in deterministic order -------------
+    # ---------- controllers --------------------------------------
     controllers:
       - joint_state_broadcaster
       - flipper_trajectory_controller

--- a/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
+++ b/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
@@ -61,6 +61,10 @@ private:
   void verifyFinalStates();
   void parseControllerInfo( const controller_manager_msgs::srv::ListControllers_Response &resp,
                             std::unordered_map<std::string, std::string> &current_state );
+  bool ensureControllerState( bool desired_state,
+                              const std::unordered_map<std::string, std::string> &current_state );
+  bool switchControllersRequest( const std::vector<std::string> &to_activate,
+                                 const std::vector<std::string> &to_deactivate );
 
   // ----- parameters -----
   std::vector<std::string> hw_interfaces_;

--- a/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
+++ b/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
@@ -48,6 +48,7 @@ private:
   // ----- helper structs -----
   struct ControllerCfg {
     bool activate{ true };
+    bool specified{ false }; // true if the controller was specified in the parameters
   };
 
   // ----- callbacks -----

--- a/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
+++ b/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
@@ -17,6 +17,18 @@
 namespace hector_controller_spawner
 {
 
+inline std::string vecToString( const std::vector<std::string> &vec )
+{
+  std::string result;
+  for ( const auto &s : vec ) {
+    if ( !result.empty() )
+      result += ", ";
+    result += s;
+  }
+  result += " (size: " + std::to_string( vec.size() ) + ")";
+  return result;
+}
+
 /**
  *  @brief  Multispawner waits for an (optional) e‑stop, then loads & activates
  *          hardware interfaces followed by controllers .
@@ -24,6 +36,8 @@ namespace hector_controller_spawner
 class MultiSpawner : public rclcpp::Node
 {
 public:
+  using ControllerGroup = std::vector<std::string>; // group of controllers to activate together
+
   explicit MultiSpawner();
   void initialize();
   bool is_finished() const noexcept { return done_; }
@@ -34,7 +48,6 @@ private:
   // ----- helper structs -----
   struct ControllerCfg {
     bool activate{ true };
-    std::vector<std::string> activate_as_group;
   };
 
   // ----- callbacks -----
@@ -46,11 +59,14 @@ private:
   bool configureController( const std::string &name );
   bool replicateParamsToCM();
   void verifyFinalStates();
+  void parseControllerInfo( const controller_manager_msgs::srv::ListControllers_Response &resp,
+                            std::unordered_map<std::string, std::string> &current_state );
 
   // ----- parameters -----
   std::vector<std::string> hw_interfaces_;
   std::vector<std::string> controllers_;
   std::unordered_map<std::string, ControllerCfg> controller_cfg_;
+  std::vector<ControllerGroup> controller_groups_;
   double retry_delay_{ 5.0 };
   std::string estop_topic_;
   bool started_{ false };

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -20,8 +20,8 @@ void MultiSpawner::initialize()
   for ( const auto &ctrl : controllers_ ) {
     ControllerCfg cfg;
     cfg.activate = this->declare_parameter<bool>( ctrl + ".activate", true );
-    cfg.activate_as_group = this->declare_parameter<std::vector<std::string>>(
-        ctrl + ".activate_as_group", std::vector<std::string>() );
+    // cfg.activate_as_group = this->declare_parameter<std::vector<std::string>>(
+    //     ctrl + ".activate_as_group", std::vector<std::string>() );
     controller_cfg_[ctrl] = cfg;
   }
 
@@ -110,8 +110,19 @@ void MultiSpawner::start_sequence()
     if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
          rclcpp::FutureReturnCode::SUCCESS ) {
       auto resp = fut.get();
-      for ( const auto &c : resp->controller )
-        current_state[c.name] = c.state; // ACTIVE / inactive / etc.
+      // save snapshot of states
+      for ( const auto &c : resp->controller ) { current_state[c.name] = c.state; }
+
+      // —— auto-detect chained controllers and build groups ——
+      for ( const auto &c : resp->controller ) {
+        for ( const auto &conn : c.chain_connections ) {
+          // undirected edge between c.name and conn.name
+          controller_cfg_[conn.name].activate_as_group.push_back( c.name );
+          controller_cfg_[c.name].activate_as_group.push_back( conn.name );
+          RCLCPP_INFO( get_logger(), "Added group connection between '%s' and '%s'.",
+                       c.name.c_str(), conn.name.c_str() );
+        }
+      }
     }
   }
 

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -20,6 +20,7 @@ void MultiSpawner::initialize()
   for ( const auto &ctrl : controllers_ ) {
     ControllerCfg cfg;
     cfg.activate = this->declare_parameter<bool>( ctrl + ".activate", true );
+    cfg.specified = true;
     controller_cfg_[ctrl] = cfg;
   }
 
@@ -187,8 +188,10 @@ void MultiSpawner::start_sequence()
 
   // 4) Activate / deactivate controllers in groups ------------------------
   // deactivate controllers that are active but not requested
+  RCLCPP_WARN( get_logger(), "DEACTIVATING CONTROLLERS" );
   ensureControllerState( false, current_state );
   // activate controllers that are requested
+  RCLCPP_WARN( get_logger(), "ACTIVATING CONTROLLERS" );
   ensureControllerState( true, current_state );
   // ===== Done =============================================================
   verifyFinalStates();
@@ -197,25 +200,28 @@ void MultiSpawner::start_sequence()
 }
 
 bool MultiSpawner::ensureControllerState(
-    bool desired_state, const std::unordered_map<std::string, std::string> &current_state )
+    const bool desired_state, const std::unordered_map<std::string, std::string> &current_state )
 {
   bool success = true;
   for ( const auto &group : controller_groups_ ) {
     /* Determine whether at least one controller in this group should be active. */
-    bool group_requested_active = false;
+    bool group_requested_active = false; // if any controller in the group should be active
     for ( const auto &m : group ) {
       RCLCPP_INFO( get_logger(), "Controller '%s' in group: %s", m.c_str(),
                    vecToString( group ).c_str() );
       group_requested_active |= controller_cfg_.at( m ).activate;
     }
 
+    // skip if the group is not requested to be in the desired state
     if ( group_requested_active != desired_state ) {
+      RCLCPP_INFO( get_logger(), "Group %s should not be %s", vecToString( group ).c_str(),
+                   desired_state ? "activated" : "deactivated" );
       continue;
     }
 
     /* Force any “false” members in the same group to active and warn once. */
     for ( const auto &m : group ) {
-      if ( !controller_cfg_.at( m ).activate ) {
+      if ( controller_cfg_.at( m ).activate != group_requested_active ) {
         RCLCPP_WARN( get_logger(), "Controller '%s' is in group with ['%s'] → overriding to ACTIVE.",
                      m.c_str(), vecToString( group ).c_str() );
       }
@@ -227,9 +233,11 @@ bool MultiSpawner::ensureControllerState(
     for ( const auto &m : group ) {
       auto it = current_state.find( m );
       active &= ( it != current_state.end() && it->second == "active" );
-      inactive &= ( it != current_state.end() && it->second == "inactive" );
+      inactive &= ( it != current_state.end() && it->second != "active" );
     }
-    if ( ( active && group_requested_active ) || ( !inactive && !group_requested_active ) ) {
+    if ( ( active && group_requested_active ) || ( inactive && !group_requested_active ) ) {
+      RCLCPP_INFO( get_logger(), "The group %s is already in the desired state %s",
+                   vecToString( group ).c_str(), desired_state ? "ACTIVE" : "INACTIVE" );
       continue;
     }
 
@@ -433,13 +441,18 @@ void MultiSpawner::verifyFinalStates()
 
   for ( const auto &name : controllers_ ) {
     std::string current = state.count( name ) ? state.at( name ) : "missing";
-    bool should_be_active = controller_cfg_[name].activate;
-    bool success = ( should_be_active && ( current == "active" ) ) ||
-                   ( !should_be_active && ( current == "inactive" || current == "configured" ) );
+    const bool should_be_active = controller_cfg_[name].activate;
+    const bool success =
+        ( should_be_active && ( current == "active" ) ) ||
+        ( !should_be_active && ( current == "inactive" || current == "configured" ) );
 
     if ( success ) {
       ++ok_cnt;
       report << "  " << GREEN << "✔ " << name << " → " << current << RESET << "\n";
+    } else if ( !controller_cfg_[name].specified ) {
+      ++ok_cnt;
+      report << "  " << GREEN << "(✔) " << name << " → " << current
+             << " (desired state unspecified in config)" << RESET << "\n";
     } else {
       ++fail_cnt;
       report << "  " << RED << "✘ " << name << " → " << current << RESET << "\n";

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -119,8 +119,6 @@ void MultiSpawner::start_sequence()
           // undirected edge between c.name and conn.name
           controller_cfg_[conn.name].activate_as_group.push_back( c.name );
           controller_cfg_[c.name].activate_as_group.push_back( conn.name );
-          RCLCPP_INFO( get_logger(), "Added group connection between '%s' and '%s'.",
-                       c.name.c_str(), conn.name.c_str() );
         }
       }
     }

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -90,7 +90,7 @@ void MultiSpawner::start_sequence()
   for ( const auto &hw : hw_interfaces_ ) {
     while ( rclcpp::ok() ) {
       if ( loadAndActivateHardware( hw ) ) {
-        RCLCPP_INFO( get_logger(), "Hardware '%s' is active.", hw.c_str() );
+        RCLCPP_DEBUG( get_logger(), "Hardware '%s' is active.", hw.c_str() );
         break;
       }
       RCLCPP_WARN( get_logger(), "Hardware '%s' failed – retrying in %.1fs", hw.c_str(),
@@ -188,10 +188,8 @@ void MultiSpawner::start_sequence()
 
   // 4) Activate / deactivate controllers in groups ------------------------
   // deactivate controllers that are active but not requested
-  RCLCPP_WARN( get_logger(), "DEACTIVATING CONTROLLERS" );
   ensureControllerState( false, current_state );
   // activate controllers that are requested
-  RCLCPP_WARN( get_logger(), "ACTIVATING CONTROLLERS" );
   ensureControllerState( true, current_state );
   // ===== Done =============================================================
   verifyFinalStates();
@@ -206,24 +204,20 @@ bool MultiSpawner::ensureControllerState(
   for ( const auto &group : controller_groups_ ) {
     /* Determine whether at least one controller in this group should be active. */
     bool group_requested_active = false; // if any controller in the group should be active
-    for ( const auto &m : group ) {
-      RCLCPP_INFO( get_logger(), "Controller '%s' in group: %s", m.c_str(),
-                   vecToString( group ).c_str() );
-      group_requested_active |= controller_cfg_.at( m ).activate;
-    }
+    for ( const auto &m : group ) { group_requested_active |= controller_cfg_.at( m ).activate; }
 
     // skip if the group is not requested to be in the desired state
     if ( group_requested_active != desired_state ) {
-      RCLCPP_INFO( get_logger(), "Group %s should not be %s", vecToString( group ).c_str(),
-                   desired_state ? "activated" : "deactivated" );
+      RCLCPP_DEBUG( get_logger(), "Group %s should not be %s", vecToString( group ).c_str(),
+                    desired_state ? "activated" : "deactivated" );
       continue;
     }
 
     /* Force any “false” members in the same group to active and warn once. */
     for ( const auto &m : group ) {
       if ( controller_cfg_.at( m ).activate != group_requested_active ) {
-        RCLCPP_WARN( get_logger(), "Controller '%s' is in group with ['%s'] → overriding to ACTIVE.",
-                     m.c_str(), vecToString( group ).c_str() );
+        RCLCPP_DEBUG( get_logger(), "Controller '%s' is in group with ['%s'] → overriding to ACTIVE.",
+                      m.c_str(), vecToString( group ).c_str() );
       }
     }
 
@@ -236,8 +230,8 @@ bool MultiSpawner::ensureControllerState(
       inactive &= ( it != current_state.end() && it->second != "active" );
     }
     if ( ( active && group_requested_active ) || ( inactive && !group_requested_active ) ) {
-      RCLCPP_INFO( get_logger(), "The group %s is already in the desired state %s",
-                   vecToString( group ).c_str(), desired_state ? "ACTIVE" : "INACTIVE" );
+      RCLCPP_DEBUG( get_logger(), "The group %s is already in the desired state %s",
+                    vecToString( group ).c_str(), desired_state ? "ACTIVE" : "INACTIVE" );
       continue;
     }
 
@@ -250,9 +244,9 @@ bool MultiSpawner::ensureControllerState(
       success = false;
     } else {
 
-      RCLCPP_INFO( get_logger(), "%s controller group: %s",
-                   group_requested_active ? "Activated" : "Deactivated",
-                   vecToString( group ).c_str() );
+      RCLCPP_DEBUG( get_logger(), "%s controller group: %s",
+                    group_requested_active ? "Activated" : "Deactivated",
+                    vecToString( group ).c_str() );
     }
   }
   return success;
@@ -281,8 +275,6 @@ void MultiSpawner::parseControllerInfo(
     const controller_manager_msgs::srv::ListControllers_Response &resp,
     std::unordered_map<std::string, std::string> &current_state )
 {
-  RCLCPP_WARN( get_logger(), "Received %zu controllers from list_controllers service.",
-               resp.controller.size() );
   // save snapshot of states
   for ( const auto &c : resp.controller ) { current_state[c.name] = c.state; }
 

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -185,46 +185,22 @@ void MultiSpawner::start_sequence()
     }
   }
 
-  // 3) Group switch_controller calls --------------------------------------
-  auto switch_controllers = [&]( const std::vector<std::string> &activate,
-                                 const std::vector<std::string> &deactivate ) -> bool {
-    if ( !switch_ctrl_client_->wait_for_service( 2s ) ) {
-      RCLCPP_ERROR( get_logger(), "switch_controller service unavailable" );
-      return false;
-    }
-    auto req = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
-    req->activate_controllers = activate;
-    req->deactivate_controllers = deactivate;
-    req->strictness = controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT;
-    req->timeout = rclcpp::Duration::from_seconds( 5.0 );
-
-    auto fut = switch_ctrl_client_->async_send_request( req );
-    return rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
-               rclcpp::FutureReturnCode::SUCCESS &&
-           fut.get()->ok;
-  };
-
+  // 4) Activate / deactivate controllers in groups ------------------------
   // deactivate controllers that are active but not requested
-  if ( !to_deactivate.empty() ) {
-    std::stringstream ss;
-    for ( size_t i = 0; i < to_deactivate.size(); ++i ) {
-      ss << to_deactivate[i] << ( i + 1 < to_deactivate.size() ? ", " : "" );
-    }
-    if ( !switch_controllers( {}, to_deactivate ) ) {
-      RCLCPP_ERROR( get_logger(), "Failed to deactivate controllers: %s", ss.str().c_str() );
-    } else {
-      RCLCPP_INFO( get_logger(), "Deactivated controllers: %s", ss.str().c_str() );
-    }
-  }
-  // print controller configuration
-  std::stringstream ss;
-  for ( const auto &[name, cfg] : controller_cfg_ ) {
-    ss << "Controller '" << name << "' is "
-       << ( controller_cfg_.at( name ).activate ? "ACTIVE" : "INACTIVE" ) << "\n";
-  }
-  RCLCPP_INFO( get_logger(), "%s", ss.str().c_str() );
-  for ( const auto &group : controller_groups_ ) {
+  ensureControllerState( false, current_state );
+  // activate controllers that are requested
+  ensureControllerState( true, current_state );
+  // ===== Done =============================================================
+  verifyFinalStates();
+  RCLCPP_INFO( get_logger(), " Multi Controller Spawner complete – shutting down." );
+  done_.store( true );
+}
 
+bool MultiSpawner::ensureControllerState(
+    bool desired_state, const std::unordered_map<std::string, std::string> &current_state )
+{
+  bool success = true;
+  for ( const auto &group : controller_groups_ ) {
     /* Determine whether at least one controller in this group should be active. */
     bool group_requested_active = false;
     for ( const auto &m : group ) {
@@ -232,8 +208,9 @@ void MultiSpawner::start_sequence()
                    vecToString( group ).c_str() );
       group_requested_active |= controller_cfg_.at( m ).activate;
     }
-    if ( !group_requested_active ) {
-      continue; // whole group requested inactive
+
+    if ( group_requested_active != desired_state ) {
+      continue;
     }
 
     /* Force any “false” members in the same group to active and warn once. */
@@ -244,30 +221,52 @@ void MultiSpawner::start_sequence()
       }
     }
 
-    /* Skip activation if entire group is already active. */
-    bool already_active = true;
+    /* Check if the group is already in the desired state. */
+    bool active = true;
+    bool inactive = true;
     for ( const auto &m : group ) {
       auto it = current_state.find( m );
-      already_active &= ( it != current_state.end() && it->second == "active" );
+      active &= ( it != current_state.end() && it->second == "active" );
+      inactive &= ( it != current_state.end() && it->second == "inactive" );
     }
-    if ( already_active ) {
+    if ( ( active && group_requested_active ) || ( !inactive && !group_requested_active ) ) {
       continue;
     }
 
     /* Issue one switch_controller call for this group. */
-    if ( !switch_controllers( group, /*deactivate*/ {} ) ) {
-      RCLCPP_ERROR( get_logger(), "Failed to activate controller group containing '%s'",
+    if ( ( group_requested_active && !switchControllersRequest( group, /*deactivate*/ {} ) ) ||
+         ( !group_requested_active && !switchControllersRequest( {}, group ) ) ) {
+      RCLCPP_ERROR( get_logger(), "Failed to %s controller group containing '%s'",
+                    group_requested_active ? "activate" : "deactivate",
                     vecToString( group ).c_str() );
+      success = false;
     } else {
 
-      RCLCPP_INFO( get_logger(), "Activated controller group: %s", vecToString( group ).c_str() );
+      RCLCPP_INFO( get_logger(), "%s controller group: %s",
+                   group_requested_active ? "Activated" : "Deactivated",
+                   vecToString( group ).c_str() );
     }
   }
+  return success;
+}
 
-  // ===== Done =============================================================
-  verifyFinalStates();
-  RCLCPP_INFO( get_logger(), " Multi Controller Spawner complete – shutting down." );
-  done_.store( true );
+bool MultiSpawner::switchControllersRequest( const std::vector<std::string> &to_activate,
+                                             const std::vector<std::string> &to_deactivate )
+{
+  if ( !switch_ctrl_client_->wait_for_service( 2s ) ) {
+    RCLCPP_ERROR( get_logger(), "switch_controller service unavailable" );
+    return false;
+  }
+  auto req = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
+  req->activate_controllers = to_activate;
+  req->deactivate_controllers = to_deactivate;
+  req->strictness = controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT;
+  req->timeout = rclcpp::Duration::from_seconds( 5.0 );
+
+  auto fut = switch_ctrl_client_->async_send_request( req );
+  return rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+             rclcpp::FutureReturnCode::SUCCESS &&
+         fut.get()->ok;
 }
 
 void MultiSpawner::parseControllerInfo(

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -20,8 +20,6 @@ void MultiSpawner::initialize()
   for ( const auto &ctrl : controllers_ ) {
     ControllerCfg cfg;
     cfg.activate = this->declare_parameter<bool>( ctrl + ".activate", true );
-    // cfg.activate_as_group = this->declare_parameter<std::vector<std::string>>(
-    //     ctrl + ".activate_as_group", std::vector<std::string>() );
     controller_cfg_[ctrl] = cfg;
   }
 

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -108,17 +108,7 @@ void MultiSpawner::start_sequence()
     if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
          rclcpp::FutureReturnCode::SUCCESS ) {
       auto resp = fut.get();
-      // save snapshot of states
-      for ( const auto &c : resp->controller ) { current_state[c.name] = c.state; }
-
-      // —— auto-detect chained controllers and build groups ——
-      for ( const auto &c : resp->controller ) {
-        for ( const auto &conn : c.chain_connections ) {
-          // undirected edge between c.name and conn.name
-          controller_cfg_[conn.name].activate_as_group.push_back( c.name );
-          controller_cfg_[c.name].activate_as_group.push_back( conn.name );
-        }
-      }
+      parseControllerInfo( *resp, current_state );
     }
   }
 
@@ -183,6 +173,18 @@ void MultiSpawner::start_sequence()
     }
   }
 
+  // 2.5) Re-request current state -> chained info only after configuring available----------------
+  if ( !to_load.empty() && list_ctrl_client_->wait_for_service( 2s ) ) {
+    current_state.clear();
+    auto req = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
+    auto fut = list_ctrl_client_->async_send_request( req );
+    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+         rclcpp::FutureReturnCode::SUCCESS ) {
+      auto resp = fut.get();
+      parseControllerInfo( *resp, current_state );
+    }
+  }
+
   // 3) Group switch_controller calls --------------------------------------
   auto switch_controllers = [&]( const std::vector<std::string> &activate,
                                  const std::vector<std::string> &deactivate ) -> bool {
@@ -214,22 +216,22 @@ void MultiSpawner::start_sequence()
       RCLCPP_INFO( get_logger(), "Deactivated controllers: %s", ss.str().c_str() );
     }
   }
-
-  std::unordered_set<std::string> processed;
-  for ( const auto &name : controllers_ ) {
-    if ( processed.count( name ) ) {
-      continue; // already handled as part of a group
-    }
-
-    const auto &cfg = controller_cfg_.at( name );
-    std::vector<std::string> group;
-    group.push_back( name );
-    group.insert( group.end(), cfg.activate_as_group.begin(), cfg.activate_as_group.end() );
-    processed.insert( group.begin(), group.end() );
+  // print controller configuration
+  std::stringstream ss;
+  for ( const auto &[name, cfg] : controller_cfg_ ) {
+    ss << "Controller '" << name << "' is "
+       << ( controller_cfg_.at( name ).activate ? "ACTIVE" : "INACTIVE" ) << "\n";
+  }
+  RCLCPP_INFO( get_logger(), "%s", ss.str().c_str() );
+  for ( const auto &group : controller_groups_ ) {
 
     /* Determine whether at least one controller in this group should be active. */
     bool group_requested_active = false;
-    for ( const auto &m : group ) { group_requested_active |= controller_cfg_.at( m ).activate; }
+    for ( const auto &m : group ) {
+      RCLCPP_INFO( get_logger(), "Controller '%s' in group: %s", m.c_str(),
+                   vecToString( group ).c_str() );
+      group_requested_active |= controller_cfg_.at( m ).activate;
+    }
     if ( !group_requested_active ) {
       continue; // whole group requested inactive
     }
@@ -237,9 +239,8 @@ void MultiSpawner::start_sequence()
     /* Force any “false” members in the same group to active and warn once. */
     for ( const auto &m : group ) {
       if ( !controller_cfg_.at( m ).activate ) {
-        RCLCPP_WARN( get_logger(),
-                     "Controller '%s' is in activate_as_group with '%s' → overriding to ACTIVE.",
-                     m.c_str(), name.c_str() );
+        RCLCPP_WARN( get_logger(), "Controller '%s' is in group with ['%s'] → overriding to ACTIVE.",
+                     m.c_str(), vecToString( group ).c_str() );
       }
     }
 
@@ -256,13 +257,10 @@ void MultiSpawner::start_sequence()
     /* Issue one switch_controller call for this group. */
     if ( !switch_controllers( group, /*deactivate*/ {} ) ) {
       RCLCPP_ERROR( get_logger(), "Failed to activate controller group containing '%s'",
-                    name.c_str() );
+                    vecToString( group ).c_str() );
     } else {
-      std::stringstream ss;
-      for ( size_t i = 0; i < group.size(); ++i ) {
-        ss << group[i] << ( i + 1 < group.size() ? ", " : "" );
-      }
-      RCLCPP_INFO( get_logger(), "Activated controller group: %s", ss.str().c_str() );
+
+      RCLCPP_INFO( get_logger(), "Activated controller group: %s", vecToString( group ).c_str() );
     }
   }
 
@@ -270,6 +268,67 @@ void MultiSpawner::start_sequence()
   verifyFinalStates();
   RCLCPP_INFO( get_logger(), " Multi Controller Spawner complete – shutting down." );
   done_.store( true );
+}
+
+void MultiSpawner::parseControllerInfo(
+    const controller_manager_msgs::srv::ListControllers_Response &resp,
+    std::unordered_map<std::string, std::string> &current_state )
+{
+  RCLCPP_WARN( get_logger(), "Received %zu controllers from list_controllers service.",
+               resp.controller.size() );
+  // save snapshot of states
+  for ( const auto &c : resp.controller ) { current_state[c.name] = c.state; }
+
+  // —— auto-detect chained controllers groups ——
+  for ( const auto &c : resp.controller ) {
+    for ( const auto &conn : c.chain_connections ) {
+      // check if there is a ControllerGroup that includes name or conn.name
+      bool found = false;
+      for ( auto &group : controller_groups_ ) {
+        if ( std::find( group.begin(), group.end(), c.name ) != group.end() ||
+             std::find( group.begin(), group.end(), conn.name ) != group.end() ) {
+          found = true;
+          if ( std::find( group.begin(), group.end(), c.name ) == group.end() ) {
+            group.push_back( c.name );
+          } else if ( std::find( group.begin(), group.end(), conn.name ) == group.end() ) {
+            group.push_back( conn.name );
+          }
+          break;
+        }
+      }
+      if ( !found ) {
+        // create a new group with both names
+        controller_groups_.emplace_back( std::vector{ c.name, conn.name } );
+      }
+      RCLCPP_DEBUG( get_logger(), "Controller Group Member: '%s' <-> '%s'", c.name.c_str(),
+                    conn.name.c_str() );
+    }
+  }
+  // add remaining controllers as their own groups
+  for ( const auto &c : resp.controller ) {
+    bool in_group = false;
+    for ( auto &group : controller_groups_ ) {
+      if ( std::find( group.begin(), group.end(), c.name ) != group.end() ) {
+        in_group = true;
+        break;
+      }
+    }
+    if ( !in_group ) {
+      controller_groups_.emplace_back( std::vector<std::string>{ c.name } );
+      RCLCPP_DEBUG( get_logger(), "Controller Group Member: '%s' (single)", c.name.c_str() );
+    }
+  }
+  // check if all controllers have a controller cfg, if not add them with current state
+  for ( const auto &c : resp.controller ) {
+    if ( controller_cfg_.find( c.name ) == controller_cfg_.end() ) {
+      ControllerCfg cfg;
+      cfg.activate = ( c.state == "active" );
+      controller_cfg_[c.name] = cfg;
+      controllers_.push_back( c.name );
+      RCLCPP_DEBUG( get_logger(), "Adding controller '%s' with state '%s' to config.",
+                    c.name.c_str(), c.state.c_str() );
+    }
+  }
 }
 
 bool MultiSpawner::loadAndActivateHardware( const std::string &name )


### PR DESCRIPTION
Removes the `activate_as_group` parameter of each controller config.
Instead, make sure to automatically detect groups of chained controllers that must be activated together.