### PR TITLE
Deactivate all controllers before reactivation

### DIFF
--- a/hector_controller_spawner/README.md
+++ b/hector_controller_spawner/README.md
@@ -33,8 +33,8 @@ ready to go with minimal configuration.
 | `controllers`                    | `string[]` | -       | Ordered list of controller names to load and manage.                      |
 | `<ctrl>.activate`                | `bool`     | `true`  | Should the controller be activated after loading?                         |
 | `retry_delay`                    | `double`   | `5.0`   | Delay (in seconds) between retry attempts.                                |
-| `start_delay'                     | `double`   | `0.0`   | Initial delay (in seconds) before starting the spawner process.           |
-| `srv_call_timeout_ms'             | `int`      | `5000`  | Timeout (in milliseconds) for service calls to the controller manager.    |
+| `start_delay`                     | `double`   | `0.0`   | Initial delay (in seconds) before starting the spawner process.           |
+| `srv_call_timeout_ms`             | `int`      | `5000`  | Timeout (in milliseconds) for service calls to the controller manager.    |
 | `load_groups_one_by_one`         | `bool`     | `true`  | Load controllers in groups (chained controllers together) or all at once. |
 | `estop_topic`                    | `string`   | `""`    | Topic to wait on (false ⇒ proceed). Leave empty to disable e-stop gating. |
 | `restart_after_estop_deactivation` | `bool`     | `true`  | Restart hardware and controllers after e-stop deactivation                |

--- a/hector_controller_spawner/README.md
+++ b/hector_controller_spawner/README.md
@@ -27,14 +27,18 @@ ready to go with minimal configuration.
 
 ## 🔧 Key Parameters
 
-| Name                  | Type       | Default | Description                                                               |
-|-----------------------|------------|---------|---------------------------------------------------------------------------|
-| `hardware_interfaces` | `string[]` | -       | Ordered list of hardware interface names to activate.                     |
-| `controllers`         | `string[]` | -       | Ordered list of controller names to load and manage.                      |
-| `<ctrl>.activate`     | `bool`     | `true`  | Should the controller be activated after loading?                         |
-| `retry_delay`         | `double`   | `5.0`   | Delay (in seconds) between retry attempts.                                |
-| `estop_topic`         | `string`   | `""`    | Topic to wait on (false ⇒ proceed). Leave empty to disable e-stop gating. |
-| `restart_after_estop_deactivation` |  `bool`    | `true`  | Restart hardware and controllers after e-stop deactivation          |
+| Name                             | Type       | Default | Description                                                               |
+|----------------------------------|------------|---------|---------------------------------------------------------------------------|
+| `hardware_interfaces`            | `string[]` | -       | Ordered list of hardware interface names to activate.                     |
+| `controllers`                    | `string[]` | -       | Ordered list of controller names to load and manage.                      |
+| `<ctrl>.activate`                | `bool`     | `true`  | Should the controller be activated after loading?                         |
+| `retry_delay`                    | `double`   | `5.0`   | Delay (in seconds) between retry attempts.                                |
+| `start_delay'                     | `double`   | `0.0`   | Initial delay (in seconds) before starting the spawner process.           |
+| `srv_call_timeout_ms'             | `int`      | `5000`  | Timeout (in milliseconds) for service calls to the controller manager.    |
+| `load_groups_one_by_one`         | `bool`     | `true`  | Load controllers in groups (chained controllers together) or all at once. |
+| `estop_topic`                    | `string`   | `""`    | Topic to wait on (false ⇒ proceed). Leave empty to disable e-stop gating. |
+| `restart_after_estop_deactivation` | `bool`     | `true`  | Restart hardware and controllers after e-stop deactivation                |
+
 📄 See [`athena.yaml`](config/athena.yaml) for a complete configuration example.
 
 ---

--- a/hector_controller_spawner/config/athena.yaml
+++ b/hector_controller_spawner/config/athena.yaml
@@ -6,6 +6,11 @@
 
     # How long to wait between retry attempts (HW + controllers).
     retry_delay: 5.0
+    # How long to wait before starting HW + controllers. 0.0 → start immediately.
+    start_delay: 0.0
+
+    # Timeout for service calls to the controller manager in milliseconds.
+    srv_call_timeout_ms: 5.0
 
     # ---------- hardware interfaces (activate = always) ----------
     hardware_interfaces:

--- a/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
+++ b/hector_controller_spawner/include/hector_controller_spawner/hector_controller_spawner.hpp
@@ -72,6 +72,8 @@ private:
                             std::unordered_map<std::string, std::string> &current_state );
   bool ensureControllerState( bool desired_state,
                               const std::unordered_map<std::string, std::string> &current_state );
+  bool
+  deactivateAllActiveControllers( const std::unordered_map<std::string, std::string> &current_state );
   bool loadControllerGroup( const std::vector<std::string> &to_activate,
                             const std::vector<std::string> &to_deactivate );
   bool switchControllersRequest( const std::vector<std::string> &to_activate,
@@ -89,6 +91,7 @@ private:
   std::string estop_topic_;
   bool restart_after_estop_deactivation_{ false };
   bool load_groups_one_by_one_{ true };
+  std::chrono::milliseconds srv_call_timeout_{ 2000 };
 
   std::atomic<bool> in_progress_{ false };
   std::atomic<bool> done_{ false };

--- a/hector_controller_spawner/src/hector_controller_spawner.cpp
+++ b/hector_controller_spawner/src/hector_controller_spawner.cpp
@@ -20,7 +20,8 @@ void MultiSpawner::initialize()
   restart_after_estop_deactivation_ =
       this->declare_parameter<bool>( "restart_after_estop_deactivation", true );
   load_groups_one_by_one_ = this->declare_parameter<bool>( "load_groups_one_by_one", true );
-
+  int src_call_timeout_ms = this->declare_parameter<int>( "service_call_timeout_ms", 5000 );
+  srv_call_timeout_ = std::chrono::milliseconds( src_call_timeout_ms );
   for ( const auto &ctrl : controllers_ ) {
     ControllerCfg cfg;
     cfg.activate = this->declare_parameter<bool>( ctrl + ".activate", true );
@@ -107,7 +108,7 @@ void MultiSpawner::start_sequence( bool initial_init )
     // test if hardware interfaces are available -> if not redo start sequence
     auto list_hw_fut = list_hardware_ctrl_client_->async_send_request(
         std::make_shared<controller_manager_msgs::srv::ListHardwareComponents::Request>() );
-    if ( rclcpp::spin_until_future_complete( shared_from_this(), list_hw_fut ) !=
+    if ( rclcpp::spin_until_future_complete( shared_from_this(), list_hw_fut, srv_call_timeout_ ) !=
          rclcpp::FutureReturnCode::SUCCESS ) {
       RCLCPP_WARN( get_logger(), "Failed to list hardware components" );
     }
@@ -151,7 +152,7 @@ void MultiSpawner::start_sequence( bool initial_init )
   if ( list_ctrl_client_->wait_for_service( 2s ) ) {
     auto req = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
     auto fut = list_ctrl_client_->async_send_request( req );
-    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
          rclcpp::FutureReturnCode::SUCCESS ) {
       auto resp = fut.get();
       parseControllerInfo( *resp, current_state );
@@ -224,7 +225,7 @@ void MultiSpawner::start_sequence( bool initial_init )
     current_state.clear();
     auto req = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
     auto fut = list_ctrl_client_->async_send_request( req );
-    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
          rclcpp::FutureReturnCode::SUCCESS ) {
       auto resp = fut.get();
       parseControllerInfo( *resp, current_state );
@@ -232,9 +233,21 @@ void MultiSpawner::start_sequence( bool initial_init )
   }
 
   // 4) Activate / deactivate controllers in groups ------------------------
-  // deactivate controllers that are active but not requested
-  ensureControllerState( false, current_state );
-  // activate controllers that are requested
+  // deactivate all controllers (started by the spawner)
+  // robuster to first deactivate and then re-activate in their respective groups
+  deactivateAllActiveControllers( current_state );
+
+  // update current state
+  if ( list_ctrl_client_->wait_for_service( 2s ) ) {
+    auto req = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
+    auto fut = list_ctrl_client_->async_send_request( req );
+    if ( rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
+         rclcpp::FutureReturnCode::SUCCESS ) {
+      auto resp = fut.get();
+      parseControllerInfo( *resp, current_state );
+    }
+  }
+  // 5) activate controllers that are requested
   ensureControllerState( true, current_state );
   // ===== Done =============================================================
   verifyFinalStates();
@@ -298,6 +311,25 @@ bool MultiSpawner::ensureControllerState(
   return success;
 }
 
+bool MultiSpawner::deactivateAllActiveControllers(
+    const std::unordered_map<std::string, std::string> &current_state )
+{
+  bool success = true;
+  std::vector<std::string> to_deactivate;
+  for ( const auto &group : controller_groups_ ) {
+    to_deactivate.clear();
+    // find active controllers in this group
+    for ( const auto &m : group ) {
+      if ( current_state.at( m ) == "active" ) {
+        to_deactivate.push_back( m );
+      }
+    }
+    if ( !to_deactivate.empty() )
+      success &= loadControllerGroup( {}, to_deactivate );
+  }
+  return success;
+}
+
 bool MultiSpawner::loadControllerGroup( const std::vector<std::string> &to_activate,
                                         const std::vector<std::string> &to_deactivate )
 {
@@ -338,7 +370,7 @@ bool MultiSpawner::switchControllersRequest( const std::vector<std::string> &to_
   req->timeout = rclcpp::Duration::from_seconds( 5.0 );
 
   auto fut = switch_ctrl_client_->async_send_request( req );
-  return rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+  return rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
              rclcpp::FutureReturnCode::SUCCESS &&
          fut.get()->ok;
 }
@@ -442,7 +474,7 @@ bool MultiSpawner::loadAndActivateHardware( const std::string &name )
   act_req->target_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
   act_req->target_state.label = "active";
   auto act_future = set_hw_state_client_->async_send_request( act_req );
-  if ( rclcpp::spin_until_future_complete( shared_from_this(), act_future ) !=
+  if ( rclcpp::spin_until_future_complete( shared_from_this(), act_future, srv_call_timeout_ ) !=
        rclcpp::FutureReturnCode::SUCCESS ) {
     return false;
   }
@@ -457,7 +489,7 @@ bool MultiSpawner::loadController( const std::string &name )
   const auto req = std::make_shared<controller_manager_msgs::srv::LoadController::Request>();
   req->name = name;
   auto fut = load_ctrl_client_->async_send_request( req );
-  return rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+  return rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
              rclcpp::FutureReturnCode::SUCCESS &&
          fut.get()->ok;
 }
@@ -469,38 +501,11 @@ bool MultiSpawner::configureController( const std::string &name )
   const auto req = std::make_shared<controller_manager_msgs::srv::ConfigureController::Request>();
   req->name = name;
   auto fut = configure_ctrl_client_->async_send_request( req );
-  return rclcpp::spin_until_future_complete( shared_from_this(), fut ) ==
+  return rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) ==
              rclcpp::FutureReturnCode::SUCCESS &&
          fut.get()->ok;
 }
 
-/*bool MultiSpawner::replicateParamsToCM()
-{
-  // gather *all* current parameters of this node
-  const auto names = this->list_parameters( {}, 10 ).names;
-  std::vector<rclcpp::Parameter> params;
-  params.reserve( names.size() );
-  for ( const auto &n : names ) {
-    if ( n.find( "qos_overrides" ) == std::string::npos ) {
-      params.push_back( this->get_parameter( n ) );
-      RCLCPP_INFO( get_logger(), "[MultiControllerSpawner] Adding Parameter %s.", n.c_str() );
-    }
-  }
-
-  // single atomic set_parameters call
-  auto fut = cm_param_client_->set_parameters_atomically( params );
-  if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) !=
-       rclcpp::FutureReturnCode::SUCCESS )
-    return false;
-
-  const auto result = fut.get();
-  if ( !result.successful ) {
-    RCLCPP_ERROR( get_logger(), "Atomic parameter set failed: %s", result.reason.c_str() );
-  } else {
-    RCLCPP_INFO( get_logger(), "Atomic parameter set successful." );
-  }
-  return result.successful;
-}*/
 void MultiSpawner::verifyFinalStates()
 {
   static const char *GREEN = "\033[32m";
@@ -515,7 +520,7 @@ void MultiSpawner::verifyFinalStates()
 
   auto req = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
   auto fut = list_ctrl_client_->async_send_request( req );
-  if ( rclcpp::spin_until_future_complete( shared_from_this(), fut ) !=
+  if ( rclcpp::spin_until_future_complete( shared_from_this(), fut, srv_call_timeout_ ) !=
        rclcpp::FutureReturnCode::SUCCESS ) {
     RCLCPP_WARN( get_logger(), "Failed to query controller states for final verification." );
     return;


### PR DESCRIPTION
Starting the controllers after releasing the e-stop is currently unreliable. The hardware interface returns an error in the write/read loop because it has lost connection to the motors. Then the controller manager partially deactivates the controller chain.
After activating the missing controllers, the controller chain is not properly configured.

## Changes:
- After activating the hardware interface, deactivate all controllers that are still active. Then, reactivate all controllers (in the order that respects the chain constraints).
- Additionally, added timeouts to all service calls. Avoids deadlocks in case the controller manager is not answering.