### PR TITLE
updated ci to use recursive vcs imports

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -13,87 +13,103 @@ jobs:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Setup
-        run: sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
-      - name: Set up Python
-        uses: actions/setup-python@v4
-      - name: Install and Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files
+    - name: Checkout Code
+      uses: actions/checkout@v4
+    - name: Setup
+      run: sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install and Run pre-commit
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files
 
   build-and-test:
     needs: Linting
     strategy:
       matrix:
         setup:
-          - rosdistro: jazzy
-            os: ubuntu-24.04
+        - rosdistro: jazzy
+          os: ubuntu-24.04
     runs-on: ${{ matrix.setup.os }}
     container:
       image: ros:${{ matrix.setup.rosdistro }}-ros-base
     steps:
-      - name: Install Build Tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ros-dev-tools python3-vcstool
+    - name: Install Build Tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ros-dev-tools python3-vcstool
 
-      - name: Checkout Local Repo
-        uses: actions/checkout@v4
-        with:
+    - name: Checkout Local Repo
+      uses: actions/checkout@v4
+      with:
           # Clones the repo into a folder named after itself inside src/
-          path: src/${{ github.event.repository.name }}
+        path: src/${{ github.event.repository.name }}
 
-      - name: Recursive VCS Import
-        run: |
-          cd src
-          PREVIOUS_HASH=""
+    - name: Recursive VCS Import
+      run: |
+        cd src
+        PREVIOUS_HASH=""
 
-          # This loop identifies all .repos files recursively.
-          # We use a hash of the file list to detect if a new dependency
-          # brought in its own .repos file. If the hash hasn't changed
-          # between iterations, the entire tree is resolved.
-          for i in {1..10}; do
-            REPOS_FILES=$(find . -name "*.repos")
-            CURRENT_HASH=$(echo "$REPOS_FILES" | sort | md5sum)
+        # This loop identifies all .repos files recursively.
+        # We use a hash of the file list to detect if a new dependency
+        # brought in its own .repos file. If the hash hasn't changed
+        # between iterations, the entire tree is resolved.
+        for i in {1..10}; do
+          REPOS_FILES=$(find . -name "*.repos")
+          CURRENT_HASH=$(echo "$REPOS_FILES" | sort | md5sum)
 
-            if [ "$CURRENT_HASH" == "$PREVIOUS_HASH" ]; then
-              echo "Dependency tree fully resolved at level $((i-1))."
-              break
-            fi
-
-            echo "Processing Level $i dependencies..."
-            for f in $REPOS_FILES; do
-              vcs import . < "$f"
-            done
-
-            PREVIOUS_HASH="$CURRENT_HASH"
-          done
-
-      - name: rosdep
-        run: |
-          rosdep update --rosdistro ${{ matrix.setup.rosdistro }} --include-eol-distros
-          rosdep install -y --from-paths src --ignore-src --rosdistro ${{ matrix.setup.rosdistro }}
-
-      - name: Build
-        run: |
-          source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-          colcon build --event-handlers console_direct+
-
-      - name: Test Local Packages Only
-        run: |
-          source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-
-          # Dynamically retrieve package names located only within this specific repository
-          LOCAL_PKGS=$(colcon list --names-only --path-source src/${{ github.event.repository.name }})
-
-          if [ -z "$LOCAL_PKGS" ]; then
-            echo "No local packages found to test."
-            exit 0
+          if [ "$CURRENT_HASH" == "$PREVIOUS_HASH" ]; then
+            echo "Dependency tree fully resolved at level $((i-1))."
+            break
           fi
 
-          echo "Testing: $LOCAL_PKGS"
-          colcon test --packages-select $LOCAL_PKGS --event-handlers console_direct+
-          colcon test-result --verbose
+          echo "Processing Level $i dependencies..."
+          for f in $REPOS_FILES; do
+            vcs import . < "$f"
+          done
+
+          PREVIOUS_HASH="$CURRENT_HASH"
+        done
+
+    - name: rosdep
+      run: |
+        rosdep update --rosdistro ${{ matrix.setup.rosdistro }} --include-eol-distros
+        rosdep install -y --from-paths src --ignore-src --rosdistro ${{ matrix.setup.rosdistro }}
+
+    - name: Identify Local Packages
+      run: |
+        source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
+        # Using --base-paths is the reliable way to filter by directory in colcon list
+        PKGS=$(colcon list --names-only --base-paths src/${{ github.event.repository.name }})
+
+        if [ -z "$PKGS" ]; then
+          echo "::error::No packages found in src/${{ github.event.repository.name }}"
+          exit 1
+        fi
+
+        # Save to the environment for subsequent steps in this job
+        echo "LOCAL_PKGS=$PKGS" >> $GITHUB_ENV
+        echo "Found packages: $PKGS"
+
+    - name: Build Local Packages
+      run: |
+        source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
+        # Builds local packages and only the dependencies they actually need
+        colcon build \
+          --packages-up-to ${{ env.LOCAL_PKGS }} \
+          --event-handlers console_direct+
+
+    - name: Test Local Packages
+      run: |
+        source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
+        # Only run tests for the local packages
+        colcon test \
+          --packages-select ${{ env.LOCAL_PKGS }} \
+          --event-handlers console_direct+
+
+    - name: Test Results
+      if: always()
+      run: |
+        source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
+        colcon test-result --verbose

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -1,11 +1,9 @@
 name: Lint, Build & Test
 on:
   push:
-    branches:
-      - jazzy
+    branches: [jazzy]
   pull_request:
-    branches:
-      - jazzy
+    branches: [jazzy]
 defaults:
   run:
     shell: bash
@@ -17,23 +15,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Setup
-        run: |
-          sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
-
+        run: sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
       - name: Set up Python
         uses: actions/setup-python@v4
-
       - name: Install and Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-
-
-
 
   build-and-test:
     needs: Linting
@@ -42,37 +31,69 @@ jobs:
         setup:
           - rosdistro: jazzy
             os: ubuntu-24.04
-          #- rosdistro: rolling
-          #  os: ubuntu-latest
     runs-on: ${{ matrix.setup.os }}
     container:
       image: ros:${{ matrix.setup.rosdistro }}-ros-base
     steps:
-      - name: install build tools
+      - name: Install Build Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y ros-dev-tools
-      - uses: actions/checkout@v4
+          sudo apt-get install -y ros-dev-tools python3-vcstool
+
+      - name: Checkout Local Repo
+        uses: actions/checkout@v4
         with:
-          repository: tu-darmstadt-ros-pkg/ad_kinematics
-          path: src/ad_kinematics
-      - uses: actions/checkout@v4
-        with:
-          repository: tu-darmstadt-ros-pkg/hector_ros2_utils
-          path: src/hector_ros2_utils
-      - uses: actions/checkout@v4
-        with:
-          path: src/repo
+          # Clones the repo into a folder named after itself inside src/
+          path: src/${{ github.event.repository.name }}
+
+      - name: Recursive VCS Import
+        run: |
+          cd src
+          PREVIOUS_HASH=""
+
+          # This loop identifies all .repos files recursively.
+          # We use a hash of the file list to detect if a new dependency
+          # brought in its own .repos file. If the hash hasn't changed
+          # between iterations, the entire tree is resolved.
+          for i in {1..10}; do
+            REPOS_FILES=$(find . -name "*.repos")
+            CURRENT_HASH=$(echo "$REPOS_FILES" | sort | md5sum)
+
+            if [ "$CURRENT_HASH" == "$PREVIOUS_HASH" ]; then
+              echo "Dependency tree fully resolved at level $((i-1))."
+              break
+            fi
+
+            echo "Processing Level $i dependencies..."
+            for f in $REPOS_FILES; do
+              vcs import . < "$f"
+            done
+
+            PREVIOUS_HASH="$CURRENT_HASH"
+          done
+
       - name: rosdep
         run: |
           rosdep update --rosdistro ${{ matrix.setup.rosdistro }} --include-eol-distros
           rosdep install -y --from-paths src --ignore-src --rosdistro ${{ matrix.setup.rosdistro }}
-      - name: build
+
+      - name: Build
         run: |
           source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-          colcon build
-      - name: test
+          colcon build --event-handlers console_direct+
+
+      - name: Test Local Packages Only
         run: |
           source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-          colcon test
+
+          # Dynamically retrieve package names located only within this specific repository
+          LOCAL_PKGS=$(colcon list --names-only --path-source src/${{ github.event.repository.name }})
+
+          if [ -z "$LOCAL_PKGS" ]; then
+            echo "No local packages found to test."
+            exit 0
+          fi
+
+          echo "Testing: $LOCAL_PKGS"
+          colcon test --packages-select $LOCAL_PKGS --event-handlers console_direct+
           colcon test-result --verbose

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -43,32 +43,23 @@ jobs:
     - name: Checkout Local Repo
       uses: actions/checkout@v4
       with:
-          # Clones the repo into a folder named after itself inside src/
         path: src/${{ github.event.repository.name }}
 
     - name: Recursive VCS Import
       run: |
         cd src
         PREVIOUS_HASH=""
-
-        # This loop identifies all .repos files recursively.
-        # We use a hash of the file list to detect if a new dependency
-        # brought in its own .repos file. If the hash hasn't changed
-        # between iterations, the entire tree is resolved.
         for i in {1..10}; do
           REPOS_FILES=$(find . -name "*.repos")
           CURRENT_HASH=$(echo "$REPOS_FILES" | sort | md5sum)
-
           if [ "$CURRENT_HASH" == "$PREVIOUS_HASH" ]; then
             echo "Dependency tree fully resolved at level $((i-1))."
             break
           fi
-
           echo "Processing Level $i dependencies..."
           for f in $REPOS_FILES; do
             vcs import . < "$f"
           done
-
           PREVIOUS_HASH="$CURRENT_HASH"
         done
 
@@ -80,33 +71,24 @@ jobs:
     - name: Identify Local Packages
       run: |
         source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-        # Using --base-paths is the reliable way to filter by directory in colcon list
-        PKGS=$(colcon list --names-only --base-paths src/${{ github.event.repository.name }})
-
+        # Filter for local repo and flatten newlines to spaces
+        PKGS=$(colcon list --names-only --base-paths src/${{ github.event.repository.name }} | tr '\n' ' ')
         if [ -z "$PKGS" ]; then
           echo "::error::No packages found in src/${{ github.event.repository.name }}"
           exit 1
         fi
-
-        # Save to the environment for subsequent steps in this job
         echo "LOCAL_PKGS=$PKGS" >> $GITHUB_ENV
         echo "Found packages: $PKGS"
 
     - name: Build Local Packages
       run: |
         source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-        # Builds local packages and only the dependencies they actually need
-        colcon build \
-          --packages-up-to ${{ env.LOCAL_PKGS }} \
-          --event-handlers console_direct+
+        colcon build --packages-up-to ${{ env.LOCAL_PKGS }} --event-handlers console_direct+
 
     - name: Test Local Packages
       run: |
         source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-        # Only run tests for the local packages
-        colcon test \
-          --packages-select ${{ env.LOCAL_PKGS }} \
-          --event-handlers console_direct+
+        colcon test --packages-select ${{ env.LOCAL_PKGS }} --event-handlers console_direct+
 
     - name: Test Results
       if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,70 +13,100 @@
 # See https://github.com/pre-commit/pre-commit
 
 repos:
-  # Standard hooks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-added-large-files
-      - id: check-docstring-first
-      - id: check-merge-conflict
-      - id: check-symlinks
-      - id: check-xml
-      - id: check-yaml
-        args: ["--allow-multiple-documents"]
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-      - id: trailing-whitespace
-        exclude_types: [rst]
+# Standard hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-docstring-first
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-xml
+  - id: check-yaml
+    args: [--allow-multiple-documents]
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: trailing-whitespace
+    exclude_types: [rst]
 
-  # CPP Checks
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.7
-    hooks:
-      - id: clang-format
-        name: Clang Format
-        args: [--style=file]
-        files: \.(cpp|hpp|h|c|cc)$
+# XML Formatting
+- repo: https://github.com/efrecon/pre-commit-hook-lxml
+  rev: v0.1.4
+  hooks:
+  - id: format-xml
+    files: \.(xml|urdf|srdf|xacro)$
+    exclude: (^|/)package\.xml$
+    args: [--write, --self-closing, nospace]
 
-  - repo: local
-    hooks:
-      - id: cppcheck
-        name: Cppcheck
-        entry: bash -c "cppcheck --force --quiet --inline-suppr --error-exitcode=1 --language=c++ $(find . -type d -name 'cmake-build-*' -prune -false -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' -o -name '*.cc')"
-        language: system
-        files: \.(cpp|cc|hpp|h)$
-        pass_filenames: false
 
-  # Python hooks
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
-    hooks:
-      - id: ruff-check
-        args: [ --fix ]
-      - id: ruff-format
+# YAML Formatting
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.15.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix, --indent, '2', --offset, '0']
 
-  # CMake Formatting
-  - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.13
-    hooks:
-      - id: cmake-format
-      - id: cmake-lint
+# CPP Checks
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v20.1.4
+  hooks:
+  - id: clang-format
+    name: Clang Format
+    args: [--style=file]
+    files: \.(cpp|hpp|h|c|cc)$
 
-  # Package XML
-  - repo: https://github.com/Joschi3/package_xml_validation.git
-    rev: v1.3.0
-    hooks:
-      - id: format-package-xml
-        name: Validate and Format package.xml
+- repo: local
+  hooks:
+  - id: cppcheck
+    name: Cppcheck
+    entry: bash -c "cppcheck --force --quiet --inline-suppr --error-exitcode=1 --language=c++ $(find . -type d -name 'cmake-build-*' -prune -false -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' -o -name '*.cc')"
+    language: system
+    files: \.(cpp|cc|hpp|h)$
+    pass_filenames: false
 
-  # Spellcheck
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
-    hooks:
-      - id: typos
+# Python hooks
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.7
+  hooks:
+  - id: ruff-check
+    args: [--fix]
+  - id: ruff-format
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.35.0
-    hooks:
-      - id: check-github-workflows
-        args: ["--verbose"]
+# CMake Formatting
+- repo: https://github.com/cheshirekow/cmake-format-precommit
+  rev: v0.6.13
+  hooks:
+  - id: cmake-format
+  - id: cmake-lint
+
+# Package XML
+- repo: https://github.com/Joschi3/package_xml_validation.git
+  rev: v1.3.0
+  hooks:
+  - id: format-package-xml
+    name: Validate and Format package.xml
+
+# Yaml launch and config files
+- repo: https://github.com/Joschi3/launch_config_validator.git
+  rev: v0.1.2
+  hooks:
+  - id: format-yaml-launch-and-configs
+    name: Validate ROS2 launch and config YAML files
+
+# Spellcheck
+#- repo: https://github.com/crate-ci/typos
+#  rev: v1.34.0
+#  hooks:
+#    - id: typos
+
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.33.2
+  hooks:
+  - id: check-github-workflows
+    args: [--verbose]
+  - id: check-github-actions
+    args: [--verbose]
+  - id: check-gitlab-ci
+    args: [--verbose]
+  - id: check-compose-spec
+    args: [--verbose]

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,9 @@
+repositories:
+  ad_kinematics:
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/ad_kinematics.git
+    version: jazzy
+  hector_ros2_utils:
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_ros2_utils.git
+    version: jazzy

--- a/hector_ros_controllers/hector_ros_controller_plugin.xml
+++ b/hector_ros_controllers/hector_ros_controller_plugin.xml
@@ -1,31 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <library path="libcontrollers">
-    <class name="velocity_to_position_command_controller/VelocityToPositionCommandController"
-           type="velocity_to_position_command_controller::VelocityToPositionCommandController"
-           base_class_type="controller_interface::ChainableControllerInterface">
-        <description>
+  <class name="velocity_to_position_command_controller/VelocityToPositionCommandController" type="velocity_to_position_command_controller::VelocityToPositionCommandController" base_class_type="controller_interface::ChainableControllerInterface">
+    <description>
             The velocity to position command controller provides a velocity input and converts it to position commands.
         </description>
-    </class>
-    <class name="self_collision_avoidance_controller/SelfCollisionAvoidanceController"
-           type="self_collision_avoidance_controller::SelfCollisionAvoidanceController"
-           base_class_type="controller_interface::ChainableControllerInterface">
-        <description>
+  </class>
+  <class name="self_collision_avoidance_controller/SelfCollisionAvoidanceController" type="self_collision_avoidance_controller::SelfCollisionAvoidanceController" base_class_type="controller_interface::ChainableControllerInterface">
+    <description>
             A chainable controller that only forwards joint commands if the resulting configuration is collision free.
         </description>
-    </class>
-    <class name="safety_forward_controller/SafetyForwardController"
-           type="safety_forward_controller::SafetyForwardController"
-           base_class_type="controller_interface::ChainableControllerInterface">
-        <description>
+  </class>
+  <class name="safety_forward_controller/SafetyForwardController" type="safety_forward_controller::SafetyForwardController" base_class_type="controller_interface::ChainableControllerInterface">
+    <description>
             A high-level forward controller ensuring that all command interfaces are stopped after receiving now
             commands for a specified time, i.e. disconnect to operator station.
         </description>
-    </class>
-    <class name="safety_position_controller/SafetyPositionController"
-           type="safety_position_controller::SafetyPositionController"
-           base_class_type="controller_interface::ChainableControllerInterface">
-        <description>
+  </class>
+  <class name="safety_position_controller/SafetyPositionController" type="safety_position_controller::SafetyPositionController" base_class_type="controller_interface::ChainableControllerInterface">
+    <description>
             A chainable position controller ensuring that revolute joints are unwrapped and joint limits are satisfied.
         </description>
-    </class>
+  </class>
 </library>

--- a/hector_ros_controllers/params/safety_forward_controller_parameters.yaml
+++ b/hector_ros_controllers/params/safety_forward_controller_parameters.yaml
@@ -1,8 +1,8 @@
 safety_forward_controller:
-  joints: { type: string_array, default_value: [ ], description: "Name of the joints to control" }
+  joints: {type: string_array, default_value: [], description: Name of the joints to control}
 
-  interface_type: { type: string, default_value: "", description: "Interface type of controller. Supported are 'position', 'velocity' and 'effort'." }
+  interface_type: {type: string, default_value: '', description: "Interface type of controller. Supported are 'position', 'velocity' and 'effort'."}
 
-  safety_timer_duration: { type: int, default_value: 500, description: "Temporal safety margin in ms. If now control inputs are received for this duration. All command interfaces are set to zero." }
+  safety_timer_duration: {type: int, default_value: 500, description: Temporal safety margin in ms. If now control inputs are received for this duration. All command interfaces are set to zero.}
 
-  passthrough_controller: { type: string, default_value: "", description: "Name of passthrough controller which exposes command interfaces for the specified joints" }
+  passthrough_controller: {type: string, default_value: '', description: Name of passthrough controller which exposes command interfaces for the specified joints}

--- a/hector_ros_controllers/params/safety_position_controller_parameters.yaml
+++ b/hector_ros_controllers/params/safety_position_controller_parameters.yaml
@@ -1,69 +1,69 @@
 safety_position_controller:
   joints:
     type: string_array
-    default_value: [ ]
-    description: "Names of the joints to control. Must match the joints defined in the robot URDF."
+    default_value: []
+    description: Names of the joints to control. Must match the joints defined in the robot URDF.
     read_only: true
 
   unwrap_continuous_joints:
     type: bool
     default_value: true
-    description: "If true, continuous joints are unwrapped to maintain continuity between consecutive commands."
+    description: If true, continuous joints are unwrapped to maintain continuity between consecutive commands.
 
   enforce_position_limits:
     type: bool
     default_value: true
-    description: "If true, position commands are clamped to joint limits ±epsilon according to the URDF limits."
+    description: If true, position commands are clamped to joint limits ±epsilon according to the URDF limits.
 
   check_self_collisions:
     type: bool
     default_value: true
-    description: "If true, the controller checks for potential self-collisions at the target pose before applying position commands."
+    description: If true, the controller checks for potential self-collisions at the target pose before applying position commands.
 
   collision_padding:
     type: double
     default_value: 0.0
-    description: "Minimum allowed distance in [m] between any two links to consider the robot safe from self-collisions when 'check_self_collisions' is true."
+    description: Minimum allowed distance in [m] between any two links to consider the robot safe from self-collisions when 'check_self_collisions' is true.
 
   collision_cache_epsilon:
     type: double
     default_value: 0.000001
-    description: "Epsilon in [rad] used to speed up self-collision checks by caching previous distance computations when 'check_self_collisions' is true."
+    description: Epsilon in [rad] used to speed up self-collision checks by caching previous distance computations when 'check_self_collisions' is true.
 
   block_if_too_far:
     type: bool
     default_value: true
-    description: "If true, the controller blocks position commands that are too far from the current position. Automatically true when 'check_self_collisions' is true."
+    description: If true, the controller blocks position commands that are too far from the current position. Automatically true when 'check_self_collisions' is true.
 
   block_velocity_scaling:
     type: double
     default_value: 1.5
-    description: "Scaling factor block_if_too_far. it is blocked when (target_position - current_position) > block_velocity_scaling * dt * velocity limit."
+    description: Scaling factor block_if_too_far. it is blocked when (target_position - current_position) > block_velocity_scaling * dt * velocity limit.
 
   debug_visualize_collisions:
     type: bool
     default_value: false
-    description: "If true, the controller publishes visualization markers for potential self-collisions to help with debugging."
+    description: If true, the controller publishes visualization markers for potential self-collisions to help with debugging.
 
   publish_debug_joint_states:
     type: bool
     default_value: false
-    description: "If true, the controller publishes the received target command states and the computed states as separate joint state msgs"
+    description: If true, the controller publishes the received target command states and the computed states as separate joint state msgs
     read_only: true
 
   set_current_limits:
     type: bool
     default_value: false
-    description: "If true, the controller additionally sets current limits see compliant and stiff limits"
+    description: If true, the controller additionally sets current limits see compliant and stiff limits
     read_only: true
 
   current_limits:
     __map_joints:
       compliant_limit:
         type: double
-        description: "Current limits for each joint in the group in Ampere. 'set_current_limits' must be true."
+        description: Current limits for each joint in the group in Ampere. 'set_current_limits' must be true.
         default_value: 3.0
       stiff_limit:
         type: double
         default_value: 5.0
-        description: "Default current limit for each joint in the group in Ampere. Will be set if current interface requested but compliant mode is off."
+        description: Default current limit for each joint in the group in Ampere. Will be set if current interface requested but compliant mode is off.

--- a/hector_ros_controllers/params/self_collision_avoidance_controller_parameters.yaml
+++ b/hector_ros_controllers/params/self_collision_avoidance_controller_parameters.yaml
@@ -1,12 +1,12 @@
 self_collision_avoidance_controller:
-  joints: { type: string_array, default_value: [], description: "Names of the joints whose command interfaces will be forwarded. Their child links will be considered for collision checks.", validation: { not_empty<>: null, unique<>: null } }
+  joints: {type: string_array, default_value: [], description: Names of the joints whose command interfaces will be forwarded. Their child links will be considered for collision checks., validation: {not_empty<>: null, unique<>: null}}
 
-  joint_interface_types: { type: string_array, default_value: [], description: "Type of command interfaces per joint that are forwarded." }
+  joint_interface_types: {type: string_array, default_value: [], description: Type of command interfaces per joint that are forwarded.}
 
-  joint_groups: { type: string_array, default_value: [], description: "Group associated with each joint. When commands for one or more joints in the respective group would result in collision the whole group is blocked. Specify 'None' or '' for no group. If empty no groups will be used." }
+  joint_groups: {type: string_array, default_value: [], description: Group associated with each joint. When commands for one or more joints in the respective group would result in collision the whole group is blocked. Specify 'None' or '' for no group. If empty no groups will be used.}
 
-  safety_margin: { type: double, default_value: 0.01, description: "Safety margin for collision checks" }
+  safety_margin: {type: double, default_value: 0.01, description: Safety margin for collision checks}
 
-  velocity_look_ahead_factor: { type: double, default_value: 1.0, description: "Amount of update steps in the future to predict resulting joint position based on current velocity command." }
+  velocity_look_ahead_factor: {type: double, default_value: 1.0, description: Amount of update steps in the future to predict resulting joint position based on current velocity command.}
 
-  passthrough_controller: { type: string, default_value: "", description: "Name of passthrough controller which exposes command interfaces for the specified joints" }
+  passthrough_controller: {type: string, default_value: '', description: Name of passthrough controller which exposes command interfaces for the specified joints}

--- a/hector_ros_controllers/params/velocity_to_position_command_controller_parameters.yaml
+++ b/hector_ros_controllers/params/velocity_to_position_command_controller_parameters.yaml
@@ -1,14 +1,14 @@
 velocity_to_position_command_controller:
-  joints: { type: string_array, default_value: [], description: "Name of the joints to control" }
+  joints: {type: string_array, default_value: [], description: Name of the joints to control}
 
-  synchronous_groups: { type: string_array, default_value: [], description: "Specifies" }
+  synchronous_groups: {type: string_array, default_value: [], description: Specifies}
 
-  passthrough_controller: { type: string, default_value: "", description: "Name of passthrough controller which exposes command interfaces for the specified joints" }
+  passthrough_controller: {type: string, default_value: '', description: Name of passthrough controller which exposes command interfaces for the specified joints}
 
-  e_stop_topic: { type: string, default_value: "estop_board/hard_estop", description: "Topic to subscribe to for emergency stop messages. If set, the controller will stop all commands when an emergency stop message is received." }
+  e_stop_topic: {type: string, default_value: estop_board/hard_estop, description: 'Topic to subscribe to for emergency stop messages. If set, the controller will stop all commands when an emergency stop message is received.'}
 
-  kp: { type: double, default_value: 2.0, description: "Proportional gain for the velocity to position pd-controller" }
-  kd: { type: double, default_value: 0.1, description: "Differential gain for for the velocity to position pd-controller" }
-  kp_sync: { type: double, default_value: 1.0, description: "Proportional gain for the synchronization of synced joints" }
+  kp: {type: double, default_value: 2.0, description: Proportional gain for the velocity to position pd-controller}
+  kd: {type: double, default_value: 0.1, description: Differential gain for for the velocity to position pd-controller}
+  kp_sync: {type: double, default_value: 1.0, description: Proportional gain for the synchronization of synced joints}
 
-  stopping_velocity_threshold: { type: double, default_value: 0.005, description: "Velocity threshold below which a joint is considered stopped" }
+  stopping_velocity_threshold: {type: double, default_value: 0.005, description: Velocity threshold below which a joint is considered stopped}


### PR DESCRIPTION
### Summary

This PR transitions the CI pipeline from manual repository checkouts to an automated, scalable approach using **`vcstool`** and a **`.repos`** manifest. This eliminates "dependency hell" by allowing the CI to recursively discover and clone nested dependencies.

### Changes

* **Added `dependencies.repos`**: A YAML manifest listing all external repositories required for the build.
* **Modified GitHub Actions Workflow**:
* Replaced multiple `actions/checkout` steps with a single **Recursive VCS Import** loop.
* The pipeline now scans for `.repos` files within cloned dependencies, ensuring that "dependencies of dependencies" are automatically resolved.
* Standardized the workspace structure by placing the main repository under `src/main_repo`.
* Added `python3-vcstool` to the build environment.
* Enhanced `colcon` output with `console_direct+` for better visibility into build/test logs.
