### PR TITLE
Accept srdf as parameter in SafteyPositionController and SelfCollisionAvoidanceController 

### DIFF
--- a/hector_ros_controllers/src/safety_position_controller.cpp
+++ b/hector_ros_controllers/src/safety_position_controller.cpp
@@ -44,13 +44,24 @@ controller_interface::CallbackReturn SafetyPositionController::on_init()
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  auto qos = rclcpp::QoS( 10 );
-  qos.transient_local();
-  semantic_description_sub_ = get_node()->create_subscription<std_msgs::msg::String>(
-      "robot_description_semantic", qos, [this]( const std_msgs::msg::String::SharedPtr msg ) {
-        srdf_ = msg->data;
-        srdf_received_ = true;
-      } );
+  // Get SRDF: prefer parameter, fall back to topic subscription
+  if ( get_node()->has_parameter( "robot_description_semantic" ) ) {
+    srdf_ = get_node()->get_parameter( "robot_description_semantic" ).as_string();
+  }
+  if ( !srdf_.empty() ) {
+    srdf_received_ = true;
+    RCLCPP_INFO( get_node()->get_logger(), "Loaded robot_description_semantic from parameter." );
+  } else {
+    RCLCPP_INFO( get_node()->get_logger(),
+                 "robot_description_semantic parameter not set, subscribing to topic." );
+    auto qos = rclcpp::QoS( 10 );
+    qos.transient_local();
+    semantic_description_sub_ = get_node()->create_subscription<std_msgs::msg::String>(
+        "robot_description_semantic", qos, [this]( const std_msgs::msg::String::SharedPtr msg ) {
+          srdf_ = msg->data;
+          srdf_received_ = true;
+        } );
+  }
 
   if ( params_.check_self_collisions ) {
     collision_checker_ = std::make_unique<CollisionChecker>( node, params_.collision_padding,

--- a/hector_ros_controllers/src/self_collision_avoidance_controller.cpp
+++ b/hector_ros_controllers/src/self_collision_avoidance_controller.cpp
@@ -201,15 +201,29 @@ SelfCollisionAvoidanceController::on_configure( const rclcpp_lifecycle::State & 
 
   transformTree_ = std::make_shared<ad_kinematics::Tree>( urdf );
 
-  auto qos = rclcpp::QoS( 10 );
-  qos.transient_local();
+  // Get SRDF: prefer parameter, fall back to topic subscription
   srdf_received_ = false;
-  semantic_description_sub = get_node()->create_subscription<std_msgs::msg::String>(
-      "robot_description_semantic", qos, [this, urdf]( const std_msgs::msg::String::SharedPtr msg ) {
-        srdf_ = srdf::Model();
-        srdf_.initString( *urdf, msg->data );
-        srdf_received_ = true;
-      } );
+  std::string srdf_xml;
+  if ( get_node()->has_parameter( "robot_description_semantic" ) ) {
+    srdf_xml = get_node()->get_parameter( "robot_description_semantic" ).as_string();
+  }
+  if ( !srdf_xml.empty() ) {
+    srdf_ = srdf::Model();
+    srdf_.initString( *urdf, srdf_xml );
+    srdf_received_ = true;
+    RCLCPP_INFO( get_node()->get_logger(), "Loaded robot_description_semantic from parameter." );
+  } else {
+    RCLCPP_INFO( get_node()->get_logger(),
+                 "robot_description_semantic parameter not set, subscribing to topic." );
+    auto qos = rclcpp::QoS( 10 );
+    qos.transient_local();
+    semantic_description_sub = get_node()->create_subscription<std_msgs::msg::String>(
+        "robot_description_semantic", qos, [this, urdf]( const std_msgs::msg::String::SharedPtr msg ) {
+          srdf_ = srdf::Model();
+          srdf_.initString( *urdf, msg->data );
+          srdf_received_ = true;
+        } );
+  }
 
   set_joint_infos( urdf );
 


### PR DESCRIPTION
Load the srdf as a parameter instead of relying on the latched topic.

The parameter is optional; the controller will fallback to the `robot_description_semantic` topic.