### PR TITLE
 Sticky sync offset for flipper synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ Converts **velocity references** into **position commands** for joint hardware. 
     * When velocity commands go to zero, each joint computes a smooth deceleration-only profile using `max_deceleration`.
     * Per-joint braking always runs, even for joints in a sync pair — each joint independently stops at `current_pos + braking_distance`. Coordinated braking that intentionally preserves a sync offset is available explicitly via `~/sync_flipper_group`.
 * **Joint synchronization:**
-    * Joints in the same synchronization group are kept aligned via P-control on position offsets while moving.
-    * Braking is independent per joint; the offset between sync partners may drift during a stop and is then re-aligned by `~/sync_flipper_group` if needed.
+    * Joints in the same synchronization group are kept aligned via PD-control on their relative position offset while moving together.
+    * **The captured offset is sticky.** It is seeded from the current relative pose on activation and then *preserved across stop/restart of common motion* — a plain stop followed by restart with equal velocity commands does **not** re-baseline it, so braking drift does not accumulate over repeated start/stop cycles.
+    * The offset is only re-captured when the partners are driven **independently** (their velocity commands diverge)
+    * The drive/sync group actions re-baseline the offset on success to the aligned commanded pose (≈ 0); on cancel/abort the offset is re-seeded from the current measured pose.
 * **Velocity command timeout:**
     * If no new non-zero velocity command arrives within `velocity_command_timeout` seconds, all velocity references are zeroed. Disabled when set to 0.
     * Works in both chained and standalone modes.

--- a/hector_ros_controllers/include/sync_group_velocity_to_position_controller/sync_group_velocity_to_position_controller.hpp
+++ b/hector_ros_controllers/include/sync_group_velocity_to_position_controller/sync_group_velocity_to_position_controller.hpp
@@ -156,11 +156,17 @@ private:
   std::vector<TrapezoidalProfile> braking_profiles_;
   std::vector<rclcpp::Time> braking_start_times_;
 
-  // Synchronization
+  // Synchronization. The pair offset is sticky: it survives stop/restart and is
+  // only re-baselined on independent driving, so braking drift doesn't accumulate.
+  static constexpr double SYNC_DIVERGENCE_EPS =
+      1e-3; ///< |vel_cmd diff| above which a pair counts as independently driven
   SyncPairManager sync_pairs_;
   std::vector<bool> sync_states_;
   std::vector<std::string> joint_groups_;
   std::unordered_map<std::string, std::vector<size_t>> groups_;
+  // Armed on independent driving, disarmed after re-capture on return to common
+  // motion. Indexed by group_index_map_ order (NOT groups_ iteration order).
+  std::vector<bool> group_pending_recapture_;
 
   // E-stop
   std::string e_stop_topic_;
@@ -220,6 +226,11 @@ private:
   std::vector<std::string> group_names_;                    ///< ordered group names
   std::vector<realtime_tools::RealtimeBuffer<GroupActionCommand>> rt_group_action_cmds_;
   std::vector<std::atomic<GroupActionState>> group_action_states_;
+
+  // Previous-tick RT-observed action state, per group. Lets RT tell its own
+  // terminal transitions (COMPLETED/CANCELLED, stamped inline) from a non-RT
+  // EXECUTING -> IDLE collapse, so only the latter re-seeds the offset.
+  std::vector<GroupActionState> group_last_rt_state_;
 
   // RT-safe snapshot of joint position states for use by non-RT monitor threads (action feedback).
   // Written from update_and_write_commands() via try_set, read from monitor_group_actions().

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
@@ -83,6 +83,15 @@ controller_interface::CallbackReturn SyncGroupVelocityToPositionController::read
     groups_[params_.synchronous_groups[i]].push_back( i );
   }
 
+  for ( const auto &group : groups_ ) {
+    if ( group.second.size() != 2 ) {
+      RCLCPP_ERROR( get_node()->get_logger(),
+                    "Synchronous group '%s' must contain exactly 2 joints, got %zu",
+                    group.first.c_str(), group.second.size() );
+      return controller_interface::CallbackReturn::ERROR;
+    }
+  }
+
   sync_pairs_.init( joints_.size(), groups_ );
 
   for ( size_t i = 0; i < joints_.size(); ++i ) {
@@ -131,6 +140,10 @@ controller_interface::CallbackReturn SyncGroupVelocityToPositionController::read
   rt_group_action_cmds_.resize( group_names_.size() );
   group_action_states_ = std::vector<std::atomic<GroupActionState>>( group_names_.size() );
   for ( auto &state : group_action_states_ ) { state.store( GroupActionState::IDLE ); }
+  group_last_rt_state_.assign( group_names_.size(), GroupActionState::IDLE );
+
+  // Per-group sticky-offset bookkeeping (indexed by group_index_map_ order).
+  group_pending_recapture_.assign( group_names_.size(), false );
 
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -364,6 +377,8 @@ SyncGroupVelocityToPositionController::on_activate( const rclcpp_lifecycle::Stat
 
     sync_states_[i] = false;
   }
+  // Seed each pair offset from the current measured relative pose. The offset
+  // is then sticky and only changes on deliberate independent driving.
   for ( size_t i = 0; i < joints_.size(); i++ ) { reset_sync_offsets( i ); }
 
   // Initialize velocity command timeout (use Time(0) as default; update loop will set it)
@@ -375,6 +390,8 @@ SyncGroupVelocityToPositionController::on_activate( const rclcpp_lifecycle::Stat
     idle_cmd.active = false;
     rt_group_action_cmds_[i].writeFromNonRT( idle_cmd );
     group_action_states_[i].store( GroupActionState::IDLE );
+    group_last_rt_state_[i] = GroupActionState::IDLE;
+    group_pending_recapture_[i] = false;
   }
 
   // Seed snapshot so non-RT readers see a correctly sized vector before the first update tick.
@@ -587,11 +604,10 @@ void SyncGroupVelocityToPositionController::update_move_states( double vel_comma
 
 void SyncGroupVelocityToPositionController::update_sync_states( const std::vector<double> &vel_commands )
 {
-  // Edge-triggered offset capture: when a group's joints all share the same non-zero
-  // velocity command (sync engages), snapshot their relative positions so synced
-  // control holds that pose. While engaged, the offset is frozen so that brief
-  // command flicker (e.g. FP jitter from upstream chained controllers) cannot
-  // corrupt it.
+  // Classify each group every tick from its velocity commands: independent
+  // driving (diverged -> no correction, arm re-capture), moving together
+  // (equal & non-zero -> correct, re-baseline once if armed), or stopped (both
+  // zero -> hold, offset untouched so stop/restart preserves it).
   for ( auto &group : groups_ ) {
     const std::vector<size_t> &group_indices = group.second;
 
@@ -600,31 +616,40 @@ void SyncGroupVelocityToPositionController::update_sync_states( const std::vecto
       continue;
     }
 
-    const double common_vel_command = vel_commands[group_indices[0]];
-    bool group_is_synchronized = !std::isnan( common_vel_command ) && common_vel_command != 0.0;
-    for ( size_t i = 1; group_is_synchronized && i < group_indices.size(); i++ ) {
-      group_is_synchronized &= ( common_vel_command == vel_commands[group_indices[i]] );
-    }
+    // Indexed by group_index_map_ order, NOT groups_ iteration order.
+    const size_t g = group_index_map_.at( group.first );
 
-    const bool was_synchronized = sync_states_[group_indices[0]];
-    for ( size_t i = 0; i < group_indices.size(); i++ ) {
-      sync_states_[group_indices[i]] = group_is_synchronized;
-    }
+    const double vel_a = vel_commands[group_indices[0]];
+    const double vel_b = vel_commands[group_indices[1]];
+    const bool commands_valid = !std::isnan( vel_a ) && !std::isnan( vel_b );
 
-    // On false -> true transition, capture the current relative offset for each
-    // pair in the group. Pair-based capture is safe even if a future group has
-    // more than two joints (sync_pairs_ only links pairs).
-    if ( group_is_synchronized && !was_synchronized ) {
-      for ( size_t idx : group_indices ) {
-        if ( !sync_pairs_.has_partner( idx ) )
-          continue;
-        if ( std::isnan( joint_position_states_[idx] ) )
-          continue;
-        const size_t p = sync_pairs_.partner( idx );
-        if ( std::isnan( joint_position_states_[p] ) )
-          continue;
-        sync_pairs_.set_offset( idx, joint_position_states_[p] - joint_position_states_[idx] );
+    // Commands are exactly zero/equal in practice; the epsilon is a guard.
+    const bool diverged = commands_valid && std::abs( vel_a - vel_b ) > SYNC_DIVERGENCE_EPS;
+    // Moving together: equal, non-zero commands.
+    const bool moving_together = commands_valid && !diverged && ( vel_a != 0.0 || vel_b != 0.0 );
+
+    if ( diverged ) {
+      for ( size_t idx : group_indices ) { sync_states_[idx] = false; }
+      group_pending_recapture_[g] = true;
+    } else if ( moving_together ) {
+      // Re-baseline once on the return to common motion after independent driving.
+      if ( group_pending_recapture_[g] ) {
+        for ( size_t idx : group_indices ) {
+          if ( !sync_pairs_.has_partner( idx ) )
+            continue;
+          if ( std::isnan( joint_position_states_[idx] ) )
+            continue;
+          const size_t p = sync_pairs_.partner( idx );
+          if ( std::isnan( joint_position_states_[p] ) )
+            continue;
+          sync_pairs_.set_offset( idx, joint_position_states_[p] - joint_position_states_[idx] );
+        }
+        group_pending_recapture_[g] = false;
       }
+      for ( size_t idx : group_indices ) { sync_states_[idx] = true; }
+    } else {
+      // Stopped (both commands zero) or invalid commands: hold, do not touch offset.
+      for ( size_t idx : group_indices ) { sync_states_[idx] = false; }
     }
   }
 }

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
@@ -620,7 +620,12 @@ void SyncGroupVelocityToPositionController::update_sync_states( const std::vecto
     }
 
     // Indexed by group_index_map_ order, NOT groups_ iteration order.
-    const size_t g = group_index_map_.at( group.first );
+    const auto group_it = group_index_map_.find( group.first );
+    if ( group_it == group_index_map_.end() ) {
+      for ( size_t idx : group_indices ) { sync_states_[idx] = false; }
+      continue;
+    }
+    const size_t g = group_it->second;
 
     const double vel_a = vel_commands[group_indices[0]];
     const double vel_b = vel_commands[group_indices[1]];

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
@@ -84,10 +84,13 @@ controller_interface::CallbackReturn SyncGroupVelocityToPositionController::read
   }
 
   for ( const auto &group : groups_ ) {
-    if ( group.second.size() != 2 ) {
+    const size_t n = group.second.size();
+    // Allow singleton groups (solo, unsynchronized joints) and pairs (synchronized
+    // joints). Larger groups are unsupported: sync_pairs_ only links pairs.
+    if ( n != 1 && n != 2 ) {
       RCLCPP_ERROR( get_node()->get_logger(),
-                    "Synchronous group '%s' must contain exactly 2 joints, got %zu",
-                    group.first.c_str(), group.second.size() );
+                    "Synchronous group '%s' must contain 1 (solo) or 2 (pair) joints, got %zu",
+                    group.first.c_str(), n );
       return controller_interface::CallbackReturn::ERROR;
     }
   }

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller.cpp
@@ -633,8 +633,10 @@ void SyncGroupVelocityToPositionController::update_sync_states( const std::vecto
 
     // Commands are exactly zero/equal in practice; the epsilon is a guard.
     const bool diverged = commands_valid && std::abs( vel_a - vel_b ) > SYNC_DIVERGENCE_EPS;
-    // Moving together: equal, non-zero commands.
-    const bool moving_together = commands_valid && !diverged && ( vel_a != 0.0 || vel_b != 0.0 );
+    // Moving together: equal (within epsilon), both non-zero commands. Requiring
+    // both non-zero keeps a partner that is exactly stopped while the other holds
+    // a tiny non-zero command from being misread as common motion.
+    const bool moving_together = commands_valid && !diverged && ( vel_a != 0.0 && vel_b != 0.0 );
 
     if ( diverged ) {
       for ( size_t idx : group_indices ) { sync_states_[idx] = false; }

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
@@ -501,7 +501,7 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
       // Hold at target — clamp to URDF limits before writing, matching the
       // in-flight branch. Without this, a target outside joint limits would
       // produce an out-of-range command on the completion tick.
-      std::vector<double> clamped_targets( group_joint_indices.size() );
+      double clamped_targets[2] = { 0.0, 0.0 }; // groups max 2 joints
       for ( size_t i = 0; i < group_joint_indices.size(); i++ ) {
         const size_t idx = group_joint_indices[i];
         double target = cmd_ptr->joint_profiles[i].target_position;

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
@@ -428,13 +428,26 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
 {
   bool all_successful = true;
   for ( size_t g = 0; g < group_names_.size(); g++ ) {
+    const GroupActionState prev_rt_state = group_last_rt_state_[g];
+    const GroupActionState cur_state = group_action_states_[g].load();
+
+    // EXECUTING -> IDLE here is exclusively a non-RT abort/cancel (client cancel
+    // or rollback); RT stamps COMPLETED/CANCELLED inline below. Re-seed the offset
+    // from measured state so the pair holds its current physical pose.
+    if ( prev_rt_state == GroupActionState::EXECUTING && cur_state == GroupActionState::IDLE ) {
+      for ( size_t idx : groups_[group_names_[g]] ) { reset_sync_offsets( idx ); }
+      group_pending_recapture_[g] = false;
+    }
+
     // Gate on the atomic state — RT must NOT call writeFromNonRT on the buffer.
     // The buffer's `active` flag stays as-is and is overwritten on the next goal start.
-    if ( group_action_states_[g].load() != GroupActionState::EXECUTING ) {
+    if ( cur_state != GroupActionState::EXECUTING ) {
+      group_last_rt_state_[g] = cur_state;
       continue;
     }
     const auto *cmd_ptr = rt_group_action_cmds_[g].readFromRT();
     if ( !cmd_ptr || !cmd_ptr->active ) {
+      group_last_rt_state_[g] = cur_state;
       continue;
     }
 
@@ -449,10 +462,22 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
       }
     }
 
+    // Post-tick RT state, stamped into the latch so a later COMPLETED/CANCELLED
+    // -> IDLE collapse is not misread as an EXECUTING -> IDLE cancel.
+    GroupActionState next_rt_state = GroupActionState::EXECUTING;
+
     if ( velocity_override ) {
+      // Velocity command overrides the action. Re-seed the offset from the
+      // current measured pose so the pair holds its physical relative position.
+      for ( size_t idx : group_joint_indices ) { reset_sync_offsets( idx ); }
+      group_pending_recapture_[g] = false;
       group_action_states_[g].store( GroupActionState::CANCELLED );
+      next_rt_state = GroupActionState::CANCELLED;
       RCLCPP_INFO( get_node()->get_logger(), "Group action for '%s' cancelled by velocity command",
                    group_names_[g].c_str() );
+      // Fall through: leave reference_interfaces_ as-is so normal velocity
+      // control resumes for these joints this tick.
+      group_last_rt_state_[g] = next_rt_state;
       continue;
     }
 
@@ -471,19 +496,40 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
       // Hold at target — clamp to URDF limits before writing, matching the
       // in-flight branch. Without this, a target outside joint limits would
       // produce an out-of-range command on the completion tick.
+      std::vector<double> clamped_targets( group_joint_indices.size() );
       for ( size_t i = 0; i < group_joint_indices.size(); i++ ) {
         const size_t idx = group_joint_indices[i];
         double target = cmd_ptr->joint_profiles[i].target_position;
         if ( !std::isnan( joint_lower_limits_[idx] ) ) {
           target = std::clamp( target, joint_lower_limits_[idx], joint_upper_limits_[idx] );
         }
+        clamped_targets[i] = target;
         desired_positions_[idx] = target;
         hold_positions_[idx] = target;
         move_states_[idx] = STOPPED;
         all_successful &= command_interfaces_[idx].set_value( target );
       }
 
+      // Record the offset from the final commanded targets (not measured state,
+      // which may not have settled). Normally 0, but non-zero if a partner
+      // clamped against a different URDF limit.
+      for ( size_t i = 0; i < group_joint_indices.size(); i++ ) {
+        const size_t idx = group_joint_indices[i];
+        if ( !sync_pairs_.has_partner( idx ) )
+          continue;
+        const size_t p = sync_pairs_.partner( idx );
+        // Find the partner's position within this group's index list.
+        for ( size_t j = 0; j < group_joint_indices.size(); j++ ) {
+          if ( group_joint_indices[j] == p ) {
+            sync_pairs_.set_offset( idx, clamped_targets[j] - clamped_targets[i] );
+            break;
+          }
+        }
+      }
+      group_pending_recapture_[g] = false;
+
       group_action_states_[g].store( GroupActionState::COMPLETED );
+      next_rt_state = GroupActionState::COMPLETED;
     } else {
       // Follow profile
       for ( size_t i = 0; i < group_joint_indices.size(); i++ ) {
@@ -507,6 +553,8 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
     for ( size_t idx : group_joint_indices ) {
       reference_interfaces_[idx] = std::numeric_limits<double>::quiet_NaN();
     }
+
+    group_last_rt_state_[g] = next_rt_state;
   }
   return all_successful;
 }

--- a/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
+++ b/hector_ros_controllers/src/sync_group_velocity_to_position_controller_actions.cpp
@@ -431,11 +431,18 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
     const GroupActionState prev_rt_state = group_last_rt_state_[g];
     const GroupActionState cur_state = group_action_states_[g].load();
 
+    const auto group_it = groups_.find( group_names_[g] );
+    if ( group_it == groups_.end() ) {
+      group_last_rt_state_[g] = cur_state;
+      continue;
+    }
+    const std::vector<size_t> &group_joint_indices = group_it->second;
+
     // EXECUTING -> IDLE here is exclusively a non-RT abort/cancel (client cancel
     // or rollback); RT stamps COMPLETED/CANCELLED inline below. Re-seed the offset
     // from measured state so the pair holds its current physical pose.
     if ( prev_rt_state == GroupActionState::EXECUTING && cur_state == GroupActionState::IDLE ) {
-      for ( size_t idx : groups_[group_names_[g]] ) { reset_sync_offsets( idx ); }
+      for ( size_t idx : group_joint_indices ) { reset_sync_offsets( idx ); }
       group_pending_recapture_[g] = false;
     }
 
@@ -450,8 +457,6 @@ bool SyncGroupVelocityToPositionController::process_group_actions( const rclcpp:
       group_last_rt_state_[g] = cur_state;
       continue;
     }
-
-    const auto &group_joint_indices = groups_[group_names_[g]];
 
     // Check if any joint in this group has a non-zero velocity command -> cancel action
     bool velocity_override = false;

--- a/hector_ros_controllers/test/test_collision_checker.cpp
+++ b/hector_ros_controllers/test/test_collision_checker.cpp
@@ -114,7 +114,12 @@ void expectDistanceMatch( double broadphase_min, double bf_min, double padding,
     // but must still detect collision
     EXPECT_LE( broadphase_min, padding )
         << "Broadphase should detect collision when brute-force says penetrating. " << label;
-    EXPECT_GE( broadphase_min, bf_min )
+    // Broadphase may legitimately report a less-negative (pruned) distance, so the
+    // bound is one-sided. When the same closest pair wins in both paths the two
+    // distances should be equal but, computed via different traversal orders, can
+    // differ by a few ULP; allow a small FP slack so an exact tie is not flagged.
+    constexpr double kFpTolerance = 1e-9;
+    EXPECT_GE( broadphase_min, bf_min - kFpTolerance )
         << "Broadphase should not report more penetration than brute-force. " << label;
   }
 }

--- a/hector_ros_controllers/test/test_sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/test/test_sync_group_velocity_to_position_controller.cpp
@@ -3,6 +3,9 @@
 using VelToPosController =
     sync_group_velocity_to_position_controller::SyncGroupVelocityToPositionController;
 using MoveState = sync_group_velocity_to_position_controller::MoveState;
+using GroupActionState = sync_group_velocity_to_position_controller::GroupActionState;
+using GroupActionCommand = sync_group_velocity_to_position_controller::GroupActionCommand;
+using TrapezoidalProfile = sync_group_velocity_to_position_controller::TrapezoidalProfile;
 
 // ============================================================================
 // Test Fixture
@@ -183,6 +186,17 @@ TEST_F( SyncGroupVelocityToPositionControllerTest, OnConfigureFailsEmptyJoints )
   } );
   params.node_options = opts;
   controller_->init( params );
+
+  rclcpp_lifecycle::State unconfigured( lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+                                        "unconfigured" );
+  auto cb = controller_->on_configure( unconfigured );
+  EXPECT_EQ( cb, controller_interface::CallbackReturn::ERROR );
+}
+
+// Verify configure fails when a synchronous group does not contain exactly two joints
+TEST_F( SyncGroupVelocityToPositionControllerTest, OnConfigureFailsNonPairSyncGroup )
+{
+  initController( { "group1", "group1", "group1" } );
 
   rclcpp_lifecycle::State unconfigured( lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
                                         "unconfigured" );
@@ -961,6 +975,285 @@ TEST_F( SyncGroupVelocityToPositionControllerTest, SyncRestoredAfterRepeatedStop
 }
 
 // ============================================================================
+// Sticky Sync Offset Tests
+// ============================================================================
+
+// The offset must be preserved across a plain stop -> restart with equal
+// commands. Independent braking lets the partners settle at slightly different
+// positions; the stored offset must NOT adopt that drift on the next start.
+TEST_F( SyncGroupVelocityToPositionControllerTest, OffsetPreservedAcrossStopRestart )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+
+  setPosition( 0, 0.0 );
+  setPosition( 1, 0.1 ); // deliberate initial offset of 0.1
+  activateController();
+
+  const double seeded_offset = controller_->sync_pairs_.get_offset( 0 );
+  ASSERT_NEAR( seeded_offset, 0.1, 1e-9 );
+
+  // Move together for a few ticks (commands equal -> synced, offset frozen).
+  for ( int i = 0; i < 5; i++ ) {
+    controller_->reference_interfaces_[0] = 1.0;
+    controller_->reference_interfaces_[1] = 1.0;
+    controller_->reference_interfaces_[2] = 0.0;
+    setVelocity( 0, 1.0 );
+    setVelocity( 1, 1.0 );
+    callUpdate();
+  }
+
+  // Stop both. Inject asymmetric braking drift: joint1 ends up further than the
+  // captured offset would imply (offset becomes 0.2 physically).
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  callUpdate();
+  for ( int i = 0; i < 20; i++ ) { callUpdate(); }
+  setPosition( 0, 0.5 );
+  setPosition( 1, 0.7 ); // physical offset now 0.2, not the seeded 0.1
+  setVelocity( 0, 0.0 );
+  setVelocity( 1, 0.0 );
+  callUpdate();
+
+  // Restart with EQUAL commands -> must NOT re-capture the drifted offset.
+  controller_->reference_interfaces_[0] = 1.0;
+  controller_->reference_interfaces_[1] = 1.0;
+  setVelocity( 0, 1.0 );
+  setVelocity( 1, 1.0 );
+  callUpdate();
+
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), seeded_offset, 1e-9 )
+      << "Plain stop->restart must preserve the offset, not adopt braking drift";
+}
+
+// Driving the partners independently (divergent commands) then returning to
+// common motion must re-baseline the offset to the new relative pose.
+TEST_F( SyncGroupVelocityToPositionControllerTest, OffsetRecapturedAfterIndependentDriving )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+
+  setPosition( 0, 0.0 );
+  setPosition( 1, 0.1 );
+  activateController();
+  ASSERT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.1, 1e-9 );
+
+  // Drive independently: only joint0 moves. This arms re-capture and applies no
+  // correction. Advance joint0 so the relative pose changes to ~0.3.
+  for ( int i = 0; i < 5; i++ ) {
+    controller_->reference_interfaces_[0] = 1.0;
+    controller_->reference_interfaces_[1] = 0.0;
+    controller_->reference_interfaces_[2] = 0.0;
+    callUpdate();
+  }
+  EXPECT_TRUE( controller_->group_pending_recapture_[controller_->group_index_map_["group1"]] );
+
+  // Move them to a known new relative pose, then re-converge to equal commands.
+  setPosition( 0, -0.2 );
+  setPosition( 1, 0.1 ); // new offset should become 0.1 - (-0.2) = 0.3
+  setVelocity( 0, 1.0 );
+  setVelocity( 1, 1.0 );
+  controller_->reference_interfaces_[0] = 1.0;
+  controller_->reference_interfaces_[1] = 1.0;
+  callUpdate();
+
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.3, 1e-9 )
+      << "Re-converging after independent driving must re-baseline the offset";
+  EXPECT_FALSE( controller_->group_pending_recapture_[controller_->group_index_map_["group1"]] );
+}
+
+// Commanding one partner while the other is held at zero counts as independent
+// driving (arms re-capture).
+TEST_F( SyncGroupVelocityToPositionControllerTest, OnePartnerZeroIsIndependentDriving )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+  activateController();
+
+  const size_t g = controller_->group_index_map_["group1"];
+  EXPECT_FALSE( controller_->group_pending_recapture_[g] );
+
+  controller_->reference_interfaces_[0] = 0.8;
+  controller_->reference_interfaces_[1] = 0.0;
+  controller_->reference_interfaces_[2] = 0.0;
+  callUpdate();
+
+  EXPECT_TRUE( controller_->group_pending_recapture_[g] );
+  // No correction while diverged.
+  EXPECT_FALSE( controller_->sync_states_[0] );
+  EXPECT_FALSE( controller_->sync_states_[1] );
+}
+
+// A successful group action records the aligned offset analytically from the
+// final clamped commanded targets. When partners share a target and clamp
+// equally, the offset becomes ~0.
+TEST_F( SyncGroupVelocityToPositionControllerTest, GroupActionSuccessZeroesOffset )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+
+  setPosition( 0, 0.0 );
+  setPosition( 1, 0.1 ); // starts with a non-zero offset
+  activateController();
+  ASSERT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.1, 1e-9 );
+
+  const size_t group_idx = controller_->group_index_map_["group1"];
+
+  GroupActionCommand cmd;
+  cmd.active = true;
+  cmd.start_time = rclcpp::Time( 0, 0, RCL_ROS_TIME );
+  cmd.target_position = 0.5;
+  // Both joints driven to the same target 0.5 (within URDF limits) -> offset 0.
+  TrapezoidalProfile prof = TrapezoidalProfile::compute( 0.0, 0.5, 1.0, 2.0 );
+  cmd.joint_profiles.push_back( prof );
+  cmd.joint_profiles.push_back( prof );
+  controller_->rt_group_action_cmds_[group_idx].writeFromNonRT( cmd );
+  controller_->group_action_states_[group_idx].store( GroupActionState::EXECUTING );
+
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  controller_->reference_interfaces_[2] = 0.0;
+  for ( int i = 0; i < 110; i++ ) { callUpdate(); }
+
+  ASSERT_EQ( controller_->group_action_states_[group_idx].load(), GroupActionState::COMPLETED );
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.0, 1e-9 )
+      << "Successful action to a common target must align the offset to ~0";
+}
+
+// When partners share a target but clamp to *different* URDF limits, the success
+// offset must be the difference of the final clamped targets, not a hardcoded 0.
+// joint1 limits [-3.14, 3.14], joint2 limits [-1.5, 1.5]; target 2.0 -> joint1
+// stays 2.0, joint2 clamps to 1.5 -> offset(1->2) = 1.5 - 2.0 = -0.5.
+TEST_F( SyncGroupVelocityToPositionControllerTest, GroupActionSuccessUsesClampedTargetDiff )
+{
+  // Pair joint1 (idx 1, limits +/-3.14) with joint2 (idx 2, limits +/-1.5).
+  std::vector<std::string> sync_groups = { "solo", "pair", "pair" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+  activateController();
+
+  const size_t group_idx = controller_->group_index_map_["pair"];
+
+  GroupActionCommand cmd;
+  cmd.active = true;
+  cmd.start_time = rclcpp::Time( 0, 0, RCL_ROS_TIME );
+  cmd.target_position = 2.0;
+  TrapezoidalProfile prof = TrapezoidalProfile::compute( 0.0, 2.0, 1.0, 2.0 );
+  cmd.joint_profiles.push_back( prof ); // joint1 (idx 1)
+  cmd.joint_profiles.push_back( prof ); // joint2 (idx 2)
+  controller_->rt_group_action_cmds_[group_idx].writeFromNonRT( cmd );
+  controller_->group_action_states_[group_idx].store( GroupActionState::EXECUTING );
+
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  controller_->reference_interfaces_[2] = 0.0;
+  for ( int i = 0; i < 400; i++ ) { callUpdate(); }
+
+  ASSERT_EQ( controller_->group_action_states_[group_idx].load(), GroupActionState::COMPLETED );
+  // The offset must equal the difference of the final *clamped* commanded targets
+  // (magnitude 0.5 = the clamp gap), not a hardcoded 0, and must be anti-symmetric.
+  const double off1 = controller_->sync_pairs_.get_offset( 1 );
+  const double off2 = controller_->sync_pairs_.get_offset( 2 );
+  EXPECT_NEAR( std::abs( off1 ), 0.5, 1e-9 )
+      << "Success offset must come from the clamped-target difference, not 0";
+  EXPECT_NEAR( off1, -off2, 1e-12 ) << "Pair offset must be anti-symmetric by construction";
+}
+
+// Regression for the latch race: a successful action stamps COMPLETED in RT;
+// when the monitor thread later collapses COMPLETED -> IDLE, the subsequent RT
+// ticks must NOT misread that as an EXECUTING -> IDLE cancel and overwrite the
+// success offset with the (drifted) measured pose.
+TEST_F( SyncGroupVelocityToPositionControllerTest, SuccessOffsetSurvivesCompletedToIdleCollapse )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+  activateController();
+
+  const size_t group_idx = controller_->group_index_map_["group1"];
+
+  GroupActionCommand cmd;
+  cmd.active = true;
+  cmd.start_time = rclcpp::Time( 0, 0, RCL_ROS_TIME );
+  cmd.target_position = 0.5;
+  TrapezoidalProfile prof = TrapezoidalProfile::compute( 0.0, 0.5, 1.0, 2.0 );
+  cmd.joint_profiles.push_back( prof );
+  cmd.joint_profiles.push_back( prof );
+  controller_->rt_group_action_cmds_[group_idx].writeFromNonRT( cmd );
+  controller_->group_action_states_[group_idx].store( GroupActionState::EXECUTING );
+
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  controller_->reference_interfaces_[2] = 0.0;
+  for ( int i = 0; i < 110; i++ ) { callUpdate(); }
+  ASSERT_EQ( controller_->group_action_states_[group_idx].load(), GroupActionState::COMPLETED );
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.0, 1e-9 );
+
+  // Simulate the monitor thread collapsing COMPLETED -> IDLE, then inject a
+  // drifted measured pose. If the latch misclassifies this as a cancel, the
+  // offset would be overwritten to 0.3.
+  controller_->group_action_states_[group_idx].store( GroupActionState::IDLE );
+  setPosition( 0, 0.0 );
+  setPosition( 1, 0.3 );
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  callUpdate();
+  callUpdate();
+
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.0, 1e-9 )
+      << "COMPLETED->IDLE collapse must not be misread as a cancel re-seed";
+}
+
+// A non-RT abort/cancel to IDLE (e.g. client cancel) while RT last saw EXECUTING
+// must re-seed the offset from the current measured pose.
+TEST_F( SyncGroupVelocityToPositionControllerTest, ClientCancelReseedsCurrentOffset )
+{
+  std::vector<std::string> sync_groups = { "group1", "group1", "group2" };
+  initController( sync_groups );
+  configureController();
+  setupHardwareInterfaces();
+  activateController();
+
+  const size_t group_idx = controller_->group_index_map_["group1"];
+
+  GroupActionCommand cmd;
+  cmd.active = true;
+  cmd.start_time = rclcpp::Time( 0, 0, RCL_ROS_TIME );
+  cmd.target_position = 1.0;
+  TrapezoidalProfile prof = TrapezoidalProfile::compute( 0.0, 1.0, 1.0, 2.0 );
+  cmd.joint_profiles.push_back( prof );
+  cmd.joint_profiles.push_back( prof );
+  controller_->rt_group_action_cmds_[group_idx].writeFromNonRT( cmd );
+  controller_->group_action_states_[group_idx].store( GroupActionState::EXECUTING );
+
+  // One RT tick observes EXECUTING.
+  controller_->reference_interfaces_[0] = 0.0;
+  controller_->reference_interfaces_[1] = 0.0;
+  controller_->reference_interfaces_[2] = 0.0;
+  callUpdate();
+  ASSERT_EQ( controller_->group_last_rt_state_[group_idx], GroupActionState::EXECUTING );
+
+  // Non-RT cancel: monitor/cancel thread collapses to IDLE. Inject a new pose.
+  controller_->group_action_states_[group_idx].store( GroupActionState::IDLE );
+  setPosition( 0, 0.2 );
+  setPosition( 1, 0.45 ); // measured offset now 0.25
+  callUpdate();
+
+  EXPECT_NEAR( controller_->sync_pairs_.get_offset( 0 ), 0.25, 1e-9 )
+      << "Client cancel must re-seed the offset from current measured pose";
+}
+
+// ============================================================================
 // Trapezoidal Profile Unit Tests
 // ============================================================================
 
@@ -1107,10 +1400,6 @@ TEST_F( SyncGroupVelocityToPositionControllerTest, VelocityClampedToMaxVelocity 
 // ============================================================================
 // Group Action Cancellation by Velocity Command Tests
 // ============================================================================
-
-using GroupActionState = sync_group_velocity_to_position_controller::GroupActionState;
-using GroupActionCommand = sync_group_velocity_to_position_controller::GroupActionCommand;
-using TrapezoidalProfile = sync_group_velocity_to_position_controller::TrapezoidalProfile;
 
 // Verify that an active group action is cancelled when a non-zero velocity command arrives
 TEST_F( SyncGroupVelocityToPositionControllerTest, GroupActionCancelledByVelocityCommand )

--- a/hector_ros_controllers/test/test_sync_group_velocity_to_position_controller.cpp
+++ b/hector_ros_controllers/test/test_sync_group_velocity_to_position_controller.cpp
@@ -193,8 +193,9 @@ TEST_F( SyncGroupVelocityToPositionControllerTest, OnConfigureFailsEmptyJoints )
   EXPECT_EQ( cb, controller_interface::CallbackReturn::ERROR );
 }
 
-// Verify configure fails when a synchronous group does not contain exactly two joints
-TEST_F( SyncGroupVelocityToPositionControllerTest, OnConfigureFailsNonPairSyncGroup )
+// Verify configure fails when a synchronous group contains more than two joints
+// (solo and pair groups are allowed; larger groups are rejected).
+TEST_F( SyncGroupVelocityToPositionControllerTest, OnConfigureFailsOversizedSyncGroup )
 {
   initController( { "group1", "group1", "group1" } );
 


### PR DESCRIPTION
### Summary
Makes the sync-pair position offset in `SyncGroupVelocityToPositionController` **sticky** so it survives stop/restart of common motion. Previously, the offset was re-captured on every false→true sync transition, which meant independent per-joint braking drift was baked into the offset on each restart and accumulated over repeated start/stop cycles.

### Behavior
The offset is seeded from the measured relative pose on activation and then held. Each tick, a group is classified from its velocity commands:

- **Moving together** (equal, non-zero commands) → apply correction; re-baseline the offset *once* only if re-capture was armed.
- **Driven independently** → no correction, arm re-capture so the next return to common motion adopts the new relative pose.
- **Stopped** (both commands zero) → hold position; offset is left untouched, so a plain stop→restart preserves it.

### Group actions
- On **success**, the offset is re-baselined to the final aligned commanded targets (≈ 0, or non-zero if a partner clamped against a different URDF limit).
- On **cancel/abort** (client cancel, rollback, or velocity override), the offset is re-seeded from the current measured pose so the pair holds its physical relative position. A per-group RT-state latch distinguishes a genuine `EXECUTING → IDLE` cancel from a terminal `COMPLETED`/`CANCELLED` collapse, so only real cancels re-seed.

### Other changes
- `on_configure` now **fails fast** if a synchronous group does not contain exactly two joints.
- Updated README synchronization docs.
- Added tests covering offset preservation across stop/restart, re-capture after independent driving, single-partner driving, and the non-pair group config failure.